### PR TITLE
[vsso-core] Fixes ObservableVehicleProperty

### DIFF
--- a/vsso-core/docs/index-en.html
+++ b/vsso-core/docs/index-en.html
@@ -6,7 +6,7 @@
 
 
 <!-- SCHEMA.ORG METADATA -->
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"https://github.com/w3c/vsso#","image":"http://vowl.visualdataweb.org/webvowl/#iri=https://github.com/w3c/vsso#","name":"VSSo Core: Vehicle Signal Specification Core Ontology", "headline":"This ontology describes the car's attributes, branches and signals defined in the Vehicle Signal Specification.", "datePublished":"Mon Dec 06 13:42:41 IST 2021", "version":"v2.0-develop", "license":"http://creativecommons.org/licenses/by/4.0/", "author":[{"@type":"Person","name":"Benjamin Klotz"},{"@type":"Person","name":"Daniel Wilms"},{"@type":"Person","name":"Raphael Troncy"}], "contributor":[{"@type":"Person","name":"Daniel Alvarez-Coello"},{"@type":"Person","name":"Felix Loesch"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","url":"https://github.com/w3c/vsso#","image":"http://vowl.visualdataweb.org/webvowl/#iri=https://github.com/w3c/vsso#","name":"VSSo Core: Vehicle Signal Specification Core Ontology", "headline":"This ontology describes the car's attributes, branches and signals defined in the Vehicle Signal Specification.", "datePublished":"Thu Dec 09 08:40:26 IST 2021", "version":"v2.0-develop", "license":"http://creativecommons.org/licenses/by/4.0/", "author":[{"@type":"Person","name":"Benjamin Klotz"},{"@type":"Person","name":"Daniel Wilms"},{"@type":"Person","name":"Raphael Troncy"}], "contributor":[{"@type":"Person","name":"Daniel Alvarez-Coello"},{"@type":"Person","name":"Felix Loesch"}]}</script>
 
 <script src="resources/jquery.js"></script> 
 <script src="resources/marked.min.js"></script> 

--- a/vsso-core/docs/ontology.jsonld
+++ b/vsso-core/docs/ontology.jsonld
@@ -94,16 +94,16 @@
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
-    "@value" : "_ObservableVehicleProperty_ - Follows the definition of an [actuator](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/) in\nVSS. It is a [DynamicVehicleProperty](#https://github.com/w3c/vsso#DynamicVehicleProperty), which can be observed but _not_ changed.\nRefers to [sosa:ObservableProperty](https://www.w3.org/TR/vocab-ssn/#SOSAObservableProperty)"
+    "@value" : "_ObservableVehicleProperty_ - Follows the definition of an [sensor](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/) in\nVSS. It is a [DynamicVehicleProperty](#https://github.com/w3c/vsso#DynamicVehicleProperty), which can be observed but _not_ changed.\nRefers to [sosa:ObservableProperty](https://www.w3.org/TR/vocab-ssn/#SOSAObservableProperty)"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
     "@value" : "ObservableVehicleProperty"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#seeAlso" : [ {
-    "@value" : "https://www.w3.org/TR/vocab-ssn/#SOSAObservableProperty"
+    "@value" : "https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/"
   }, {
-    "@value" : "ttps://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/"
+    "@value" : "https://www.w3.org/TR/vocab-ssn/#SOSAObservableProperty"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#subClassOf" : [ {
     "@id" : "https://github.com/w3c/vsso#DynamicVehicleProperty"

--- a/vsso-core/docs/ontology.jsonld
+++ b/vsso-core/docs/ontology.jsonld
@@ -61,7 +61,7 @@
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
-    "@value" : "_ActuatableVehicleProperty_ - Follows the definition of an [actuator](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/) in\nVSS. It is a [DynamicVehicleProperty](#https://github.com/w3c/vsso#DynamicVehicleProperty), which can be changed.\nRefers to [sosa:ActuableProperty](https://www.w3.org/TR/vocab-ssn/#SOSAActuatableProperty)"
+    "@value" : "_ActuatableVehicleProperty_ - Follows the definition of an [actuator](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/) in\nVSS. It is a [DynamicVehicleProperty](#DynamicVehicleProperty), which can be changed.\nRefers to [sosa:ActuableProperty](https://www.w3.org/TR/vocab-ssn/#SOSAActuatableProperty)"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -80,7 +80,7 @@
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
-    "@value" : "_DynamicVehicleProperty_ - In contrast to a [StaticVehicleProperty](#https://github.com/w3c/vsso#StaticVehicleProperty),\nthis property is expected to change frequently, even within a vehicle lifecycle. Examples are the vehicle `speed`, `location`, etc."
+    "@value" : "_DynamicVehicleProperty_ - In contrast to a [StaticVehicleProperty](#StaticVehicleProperty),\nthis property is expected to change frequently, even within an ignition cycle. Examples are the vehicle `speed`, `location`, etc."
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -94,7 +94,7 @@
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
-    "@value" : "_ObservableVehicleProperty_ - Follows the definition of an [sensor](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/) in\nVSS. It is a [DynamicVehicleProperty](#https://github.com/w3c/vsso#DynamicVehicleProperty), which can be observed but _not_ changed.\nRefers to [sosa:ObservableProperty](https://www.w3.org/TR/vocab-ssn/#SOSAObservableProperty)"
+    "@value" : "_ObservableVehicleProperty_ - Follows the definition of an [sensor](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/) in\nVSS. It is a [DynamicVehicleProperty](#DynamicVehicleProperty), which can be observed but _not_ changed.\nRefers to [sosa:ObservableProperty](https://www.w3.org/TR/vocab-ssn/#SOSAObservableProperty)"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -124,7 +124,7 @@
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
-    "@value" : "_StaticVehicleProperty_ - Follows the definition of an [attribute](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/attributes/) in\nVSS. `StaticVehicleProperty` is meant to stay stable at least over the duration of a vehicle lifecycle.\nIf you expect more frequent updates, please consider [DynamicVehicleProperty](#https://github.com/w3c/vsso#DynamicVehicleProperty)"
+    "@value" : "_StaticVehicleProperty_ - Follows the definition of an [attribute](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/attributes/) in\nVSS. `StaticVehicleProperty` is meant to stay stable at least over the duration of an ignition cycle.\nIf you expect more frequent updates, please consider [DynamicVehicleProperty](#DynamicVehicleProperty)"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -141,7 +141,7 @@
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
-    "@value" : "_Vehicle_ - Core concept of the ontology. Collects [VehicleComponents](#https://github.com/w3c/vsso#VehicleComponent)\nand [VehicleProperties](#https://github.com/w3c/vsso#VehicleProperty) belonging to a vehicle"
+    "@value" : "_Vehicle_ - Core concept of the ontology. Collects [VehicleComponents](#VehicleComponent)\nand [VehicleProperties](#VehicleProperty) belonging to a vehicle"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -152,7 +152,7 @@
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
-    "@value" : "_VehicleComponent_ - First of all a sorting element for [VehicleProperties](#https://github.com/w3c/vsso#VehicleProperty), following on the definition of a\n[branch](https://covesa.github.io/vehicle_signal_specification/rule_set/branches/). It is encouraged to use the concept for actual parts modeled as\n`VehicleComponent."
+    "@value" : "_VehicleComponent_ - First of all a sorting element for [VehicleProperties](#VehicleProperty), following on the definition of a\n[branch](https://covesa.github.io/vehicle_signal_specification/rule_set/branches/). It is encouraged to use the concept for actual parts modeled as\n`VehicleComponent."
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",
@@ -166,7 +166,7 @@
   "@type" : [ "http://www.w3.org/2002/07/owl#Class" ],
   "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
     "@language" : "en",
-    "@value" : "_VehicleProperty_ - Central concept for defining a vehicle, either through a VehicleComponent structure\nor connected directly to the vehicle. Every VehicleProperty shall be instantiated with a [vehiclePropertyValue](#https://github.com/w3c/vsso#vehiclePropertyValue).\nIt is good practice to set the time when the value was updated through [valueUpdatedAt](#https://github.com/w3c/vsso#valueUpdatedAt)\nThe VehicleProperty follows the concept of a [ssn:Property](https://www.w3.org/TR/vocab-ssn/#SSNProperty)"
+    "@value" : "_VehicleProperty_ - Central concept for defining a vehicle, either through a VehicleComponent structure\nor connected directly to the vehicle. Every VehicleProperty shall be instantiated with a [vehiclePropertyValue](#vehiclePropertyValue).\nIt is good practice to set the time when the value was updated through [propertyValueUpdatedAt](#propertyValueUpdatedAt)\nThe VehicleProperty follows the concept of a [ssn:Property](https://www.w3.org/TR/vocab-ssn/#SSNProperty)"
   } ],
   "http://www.w3.org/2000/01/rdf-schema#label" : [ {
     "@language" : "en",

--- a/vsso-core/docs/ontology.nt
+++ b/vsso-core/docs/ontology.nt
@@ -130,7 +130,7 @@
 # https://github.com/w3c/vsso#ActuatableVehicleProperty
 <https://github.com/w3c/vsso#ActuatableVehicleProperty> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
 <https://github.com/w3c/vsso#ActuatableVehicleProperty> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://github.com/w3c/vsso#DynamicVehicleProperty> .
-<https://github.com/w3c/vsso#ActuatableVehicleProperty> <http://www.w3.org/2000/01/rdf-schema#comment> "_ActuatableVehicleProperty_ - Follows the definition of an [actuator](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/) in\nVSS. It is a [DynamicVehicleProperty](#https://github.com/w3c/vsso#DynamicVehicleProperty), which can be changed.\nRefers to [sosa:ActuableProperty](https://www.w3.org/TR/vocab-ssn/#SOSAActuatableProperty)"@en .
+<https://github.com/w3c/vsso#ActuatableVehicleProperty> <http://www.w3.org/2000/01/rdf-schema#comment> "_ActuatableVehicleProperty_ - Follows the definition of an [actuator](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/) in\nVSS. It is a [DynamicVehicleProperty](#DynamicVehicleProperty), which can be changed.\nRefers to [sosa:ActuableProperty](https://www.w3.org/TR/vocab-ssn/#SOSAActuatableProperty)"@en .
 <https://github.com/w3c/vsso#ActuatableVehicleProperty> <http://www.w3.org/2000/01/rdf-schema#label> "ActuatableVehicleProperty"@en .
 <https://github.com/w3c/vsso#ActuatableVehicleProperty> <http://www.w3.org/2000/01/rdf-schema#seeAlso> "https://www.w3.org/TR/vocab-ssn/#SOSAActuatableProperty" .
 <https://github.com/w3c/vsso#ActuatableVehicleProperty> <http://www.w3.org/2000/01/rdf-schema#seeAlso> "ttps://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/" .
@@ -138,13 +138,13 @@
 # https://github.com/w3c/vsso#DynamicVehicleProperty
 <https://github.com/w3c/vsso#DynamicVehicleProperty> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
 <https://github.com/w3c/vsso#DynamicVehicleProperty> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://github.com/w3c/vsso#VehicleProperty> .
-<https://github.com/w3c/vsso#DynamicVehicleProperty> <http://www.w3.org/2000/01/rdf-schema#comment> "_DynamicVehicleProperty_ - In contrast to a [StaticVehicleProperty](#https://github.com/w3c/vsso#StaticVehicleProperty),\nthis property is expected to change frequently, even within a vehicle lifecycle. Examples are the vehicle `speed`, `location`, etc."@en .
+<https://github.com/w3c/vsso#DynamicVehicleProperty> <http://www.w3.org/2000/01/rdf-schema#comment> "_DynamicVehicleProperty_ - In contrast to a [StaticVehicleProperty](#StaticVehicleProperty),\nthis property is expected to change frequently, even within an ignition cycle. Examples are the vehicle `speed`, `location`, etc."@en .
 <https://github.com/w3c/vsso#DynamicVehicleProperty> <http://www.w3.org/2000/01/rdf-schema#label> "DynamicVehicleProperty"@en .
 # 
 # https://github.com/w3c/vsso#ObservableVehicleProperty
 <https://github.com/w3c/vsso#ObservableVehicleProperty> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
 <https://github.com/w3c/vsso#ObservableVehicleProperty> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://github.com/w3c/vsso#DynamicVehicleProperty> .
-<https://github.com/w3c/vsso#ObservableVehicleProperty> <http://www.w3.org/2000/01/rdf-schema#comment> "_ObservableVehicleProperty_ - Follows the definition of an [sensor](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/) in\nVSS. It is a [DynamicVehicleProperty](#https://github.com/w3c/vsso#DynamicVehicleProperty), which can be observed but _not_ changed.\nRefers to [sosa:ObservableProperty](https://www.w3.org/TR/vocab-ssn/#SOSAObservableProperty)"@en .
+<https://github.com/w3c/vsso#ObservableVehicleProperty> <http://www.w3.org/2000/01/rdf-schema#comment> "_ObservableVehicleProperty_ - Follows the definition of an [sensor](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/) in\nVSS. It is a [DynamicVehicleProperty](#DynamicVehicleProperty), which can be observed but _not_ changed.\nRefers to [sosa:ObservableProperty](https://www.w3.org/TR/vocab-ssn/#SOSAObservableProperty)"@en .
 <https://github.com/w3c/vsso#ObservableVehicleProperty> <http://www.w3.org/2000/01/rdf-schema#label> "ObservableVehicleProperty"@en .
 <https://github.com/w3c/vsso#ObservableVehicleProperty> <http://www.w3.org/2000/01/rdf-schema#seeAlso> "https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/" .
 <https://github.com/w3c/vsso#ObservableVehicleProperty> <http://www.w3.org/2000/01/rdf-schema#seeAlso> "https://www.w3.org/TR/vocab-ssn/#SOSAObservableProperty" .
@@ -157,24 +157,24 @@
 # https://github.com/w3c/vsso#StaticVehicleProperty
 <https://github.com/w3c/vsso#StaticVehicleProperty> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
 <https://github.com/w3c/vsso#StaticVehicleProperty> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://github.com/w3c/vsso#VehicleProperty> .
-<https://github.com/w3c/vsso#StaticVehicleProperty> <http://www.w3.org/2000/01/rdf-schema#comment> "_StaticVehicleProperty_ - Follows the definition of an [attribute](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/attributes/) in\nVSS. `StaticVehicleProperty` is meant to stay stable at least over the duration of a vehicle lifecycle.\nIf you expect more frequent updates, please consider [DynamicVehicleProperty](#https://github.com/w3c/vsso#DynamicVehicleProperty)"@en .
+<https://github.com/w3c/vsso#StaticVehicleProperty> <http://www.w3.org/2000/01/rdf-schema#comment> "_StaticVehicleProperty_ - Follows the definition of an [attribute](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/attributes/) in\nVSS. `StaticVehicleProperty` is meant to stay stable at least over the duration of an ignition cycle.\nIf you expect more frequent updates, please consider [DynamicVehicleProperty](#DynamicVehicleProperty)"@en .
 <https://github.com/w3c/vsso#StaticVehicleProperty> <http://www.w3.org/2000/01/rdf-schema#label> "StaticVehicleProperty"@en .
 <https://github.com/w3c/vsso#StaticVehicleProperty> <http://www.w3.org/2000/01/rdf-schema#seeAlso> "https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/attributes/" .
 # 
 # https://github.com/w3c/vsso#Vehicle
 <https://github.com/w3c/vsso#Vehicle> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
-<https://github.com/w3c/vsso#Vehicle> <http://www.w3.org/2000/01/rdf-schema#comment> "_Vehicle_ - Core concept of the ontology. Collects [VehicleComponents](#https://github.com/w3c/vsso#VehicleComponent)\nand [VehicleProperties](#https://github.com/w3c/vsso#VehicleProperty) belonging to a vehicle"@en .
+<https://github.com/w3c/vsso#Vehicle> <http://www.w3.org/2000/01/rdf-schema#comment> "_Vehicle_ - Core concept of the ontology. Collects [VehicleComponents](#VehicleComponent)\nand [VehicleProperties](#VehicleProperty) belonging to a vehicle"@en .
 <https://github.com/w3c/vsso#Vehicle> <http://www.w3.org/2000/01/rdf-schema#label> "Vehicle"@en .
 # 
 # https://github.com/w3c/vsso#VehicleComponent
 <https://github.com/w3c/vsso#VehicleComponent> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
-<https://github.com/w3c/vsso#VehicleComponent> <http://www.w3.org/2000/01/rdf-schema#comment> "_VehicleComponent_ - First of all a sorting element for [VehicleProperties](#https://github.com/w3c/vsso#VehicleProperty), following on the definition of a\n[branch](https://covesa.github.io/vehicle_signal_specification/rule_set/branches/). It is encouraged to use the concept for actual parts modeled as\n`VehicleComponent."@en .
+<https://github.com/w3c/vsso#VehicleComponent> <http://www.w3.org/2000/01/rdf-schema#comment> "_VehicleComponent_ - First of all a sorting element for [VehicleProperties](#VehicleProperty), following on the definition of a\n[branch](https://covesa.github.io/vehicle_signal_specification/rule_set/branches/). It is encouraged to use the concept for actual parts modeled as\n`VehicleComponent."@en .
 <https://github.com/w3c/vsso#VehicleComponent> <http://www.w3.org/2000/01/rdf-schema#label> "VehicleComponent"@en .
 <https://github.com/w3c/vsso#VehicleComponent> <http://www.w3.org/2000/01/rdf-schema#seeAlso> "https://covesa.github.io/vehicle_signal_specification/rule_set/branches/" .
 # 
 # https://github.com/w3c/vsso#VehicleProperty
 <https://github.com/w3c/vsso#VehicleProperty> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
-<https://github.com/w3c/vsso#VehicleProperty> <http://www.w3.org/2000/01/rdf-schema#comment> "_VehicleProperty_ - Central concept for defining a vehicle, either through a VehicleComponent structure\nor connected directly to the vehicle. Every VehicleProperty shall be instantiated with a [vehiclePropertyValue](#https://github.com/w3c/vsso#vehiclePropertyValue).\nIt is good practice to set the time when the value was updated through [valueUpdatedAt](#https://github.com/w3c/vsso#valueUpdatedAt)\nThe VehicleProperty follows the concept of a [ssn:Property](https://www.w3.org/TR/vocab-ssn/#SSNProperty)"@en .
+<https://github.com/w3c/vsso#VehicleProperty> <http://www.w3.org/2000/01/rdf-schema#comment> "_VehicleProperty_ - Central concept for defining a vehicle, either through a VehicleComponent structure\nor connected directly to the vehicle. Every VehicleProperty shall be instantiated with a [vehiclePropertyValue](#vehiclePropertyValue).\nIt is good practice to set the time when the value was updated through [propertyValueUpdatedAt](#propertyValueUpdatedAt)\nThe VehicleProperty follows the concept of a [ssn:Property](https://www.w3.org/TR/vocab-ssn/#SSNProperty)"@en .
 <https://github.com/w3c/vsso#VehicleProperty> <http://www.w3.org/2000/01/rdf-schema#label> "VehicleProperty"@en .
 <https://github.com/w3c/vsso#VehicleProperty> <http://www.w3.org/2000/01/rdf-schema#seeAlso> "https://www.w3.org/TR/vocab-ssn/#SSNProperty" .
 # 

--- a/vsso-core/docs/ontology.nt
+++ b/vsso-core/docs/ontology.nt
@@ -144,10 +144,10 @@
 # https://github.com/w3c/vsso#ObservableVehicleProperty
 <https://github.com/w3c/vsso#ObservableVehicleProperty> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .
 <https://github.com/w3c/vsso#ObservableVehicleProperty> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <https://github.com/w3c/vsso#DynamicVehicleProperty> .
-<https://github.com/w3c/vsso#ObservableVehicleProperty> <http://www.w3.org/2000/01/rdf-schema#comment> "_ObservableVehicleProperty_ - Follows the definition of an [actuator](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/) in\nVSS. It is a [DynamicVehicleProperty](#https://github.com/w3c/vsso#DynamicVehicleProperty), which can be observed but _not_ changed.\nRefers to [sosa:ObservableProperty](https://www.w3.org/TR/vocab-ssn/#SOSAObservableProperty)"@en .
+<https://github.com/w3c/vsso#ObservableVehicleProperty> <http://www.w3.org/2000/01/rdf-schema#comment> "_ObservableVehicleProperty_ - Follows the definition of an [sensor](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/) in\nVSS. It is a [DynamicVehicleProperty](#https://github.com/w3c/vsso#DynamicVehicleProperty), which can be observed but _not_ changed.\nRefers to [sosa:ObservableProperty](https://www.w3.org/TR/vocab-ssn/#SOSAObservableProperty)"@en .
 <https://github.com/w3c/vsso#ObservableVehicleProperty> <http://www.w3.org/2000/01/rdf-schema#label> "ObservableVehicleProperty"@en .
+<https://github.com/w3c/vsso#ObservableVehicleProperty> <http://www.w3.org/2000/01/rdf-schema#seeAlso> "https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/" .
 <https://github.com/w3c/vsso#ObservableVehicleProperty> <http://www.w3.org/2000/01/rdf-schema#seeAlso> "https://www.w3.org/TR/vocab-ssn/#SOSAObservableProperty" .
-<https://github.com/w3c/vsso#ObservableVehicleProperty> <http://www.w3.org/2000/01/rdf-schema#seeAlso> "ttps://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/" .
 # 
 # https://github.com/w3c/vsso#PositionInVehicle
 <https://github.com/w3c/vsso#PositionInVehicle> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .

--- a/vsso-core/docs/ontology.rdf
+++ b/vsso-core/docs/ontology.rdf
@@ -235,7 +235,7 @@ StaticVehicleComponent.</rdfs:comment>
     <owl:Class rdf:about="https://github.com/w3c/vsso#ActuatableVehicleProperty">
         <rdfs:subClassOf rdf:resource="https://github.com/w3c/vsso#DynamicVehicleProperty"/>
         <rdfs:comment xml:lang="en">_ActuatableVehicleProperty_ - Follows the definition of an [actuator](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/) in
-VSS. It is a [DynamicVehicleProperty](#https://github.com/w3c/vsso#DynamicVehicleProperty), which can be changed.
+VSS. It is a [DynamicVehicleProperty](#DynamicVehicleProperty), which can be changed.
 Refers to [sosa:ActuableProperty](https://www.w3.org/TR/vocab-ssn/#SOSAActuatableProperty)</rdfs:comment>
         <rdfs:label xml:lang="en">ActuatableVehicleProperty</rdfs:label>
         <rdfs:seeAlso>https://www.w3.org/TR/vocab-ssn/#SOSAActuatableProperty</rdfs:seeAlso>
@@ -249,8 +249,8 @@ Refers to [sosa:ActuableProperty](https://www.w3.org/TR/vocab-ssn/#SOSAActuatabl
 
     <owl:Class rdf:about="https://github.com/w3c/vsso#DynamicVehicleProperty">
         <rdfs:subClassOf rdf:resource="https://github.com/w3c/vsso#VehicleProperty"/>
-        <rdfs:comment xml:lang="en">_DynamicVehicleProperty_ - In contrast to a [StaticVehicleProperty](#https://github.com/w3c/vsso#StaticVehicleProperty),
-this property is expected to change frequently, even within a vehicle lifecycle. Examples are the vehicle `speed`, `location`, etc.</rdfs:comment>
+        <rdfs:comment xml:lang="en">_DynamicVehicleProperty_ - In contrast to a [StaticVehicleProperty](#StaticVehicleProperty),
+this property is expected to change frequently, even within an ignition cycle. Examples are the vehicle `speed`, `location`, etc.</rdfs:comment>
         <rdfs:label xml:lang="en">DynamicVehicleProperty</rdfs:label>
     </owl:Class>
     
@@ -262,7 +262,7 @@ this property is expected to change frequently, even within a vehicle lifecycle.
     <owl:Class rdf:about="https://github.com/w3c/vsso#ObservableVehicleProperty">
         <rdfs:subClassOf rdf:resource="https://github.com/w3c/vsso#DynamicVehicleProperty"/>
         <rdfs:comment xml:lang="en">_ObservableVehicleProperty_ - Follows the definition of an [sensor](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/) in
-VSS. It is a [DynamicVehicleProperty](#https://github.com/w3c/vsso#DynamicVehicleProperty), which can be observed but _not_ changed.
+VSS. It is a [DynamicVehicleProperty](#DynamicVehicleProperty), which can be observed but _not_ changed.
 Refers to [sosa:ObservableProperty](https://www.w3.org/TR/vocab-ssn/#SOSAObservableProperty)</rdfs:comment>
         <rdfs:label xml:lang="en">ObservableVehicleProperty</rdfs:label>
         <rdfs:seeAlso>https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/</rdfs:seeAlso>
@@ -289,8 +289,8 @@ They can be named with the positionName property.</rdfs:comment>
     <owl:Class rdf:about="https://github.com/w3c/vsso#StaticVehicleProperty">
         <rdfs:subClassOf rdf:resource="https://github.com/w3c/vsso#VehicleProperty"/>
         <rdfs:comment xml:lang="en">_StaticVehicleProperty_ - Follows the definition of an [attribute](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/attributes/) in
-VSS. `StaticVehicleProperty` is meant to stay stable at least over the duration of a vehicle lifecycle.
-If you expect more frequent updates, please consider [DynamicVehicleProperty](#https://github.com/w3c/vsso#DynamicVehicleProperty)</rdfs:comment>
+VSS. `StaticVehicleProperty` is meant to stay stable at least over the duration of an ignition cycle.
+If you expect more frequent updates, please consider [DynamicVehicleProperty](#DynamicVehicleProperty)</rdfs:comment>
         <rdfs:label xml:lang="en">StaticVehicleProperty</rdfs:label>
         <rdfs:seeAlso>https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/attributes/</rdfs:seeAlso>
     </owl:Class>
@@ -301,8 +301,8 @@ If you expect more frequent updates, please consider [DynamicVehicleProperty](#h
 
 
     <owl:Class rdf:about="https://github.com/w3c/vsso#Vehicle">
-        <rdfs:comment xml:lang="en">_Vehicle_ - Core concept of the ontology. Collects [VehicleComponents](#https://github.com/w3c/vsso#VehicleComponent)
-and [VehicleProperties](#https://github.com/w3c/vsso#VehicleProperty) belonging to a vehicle</rdfs:comment>
+        <rdfs:comment xml:lang="en">_Vehicle_ - Core concept of the ontology. Collects [VehicleComponents](#VehicleComponent)
+and [VehicleProperties](#VehicleProperty) belonging to a vehicle</rdfs:comment>
         <rdfs:label xml:lang="en">Vehicle</rdfs:label>
     </owl:Class>
     
@@ -312,7 +312,7 @@ and [VehicleProperties](#https://github.com/w3c/vsso#VehicleProperty) belonging 
 
 
     <owl:Class rdf:about="https://github.com/w3c/vsso#VehicleComponent">
-        <rdfs:comment xml:lang="en">_VehicleComponent_ - First of all a sorting element for [VehicleProperties](#https://github.com/w3c/vsso#VehicleProperty), following on the definition of a
+        <rdfs:comment xml:lang="en">_VehicleComponent_ - First of all a sorting element for [VehicleProperties](#VehicleProperty), following on the definition of a
 [branch](https://covesa.github.io/vehicle_signal_specification/rule_set/branches/). It is encouraged to use the concept for actual parts modeled as
 `VehicleComponent.</rdfs:comment>
         <rdfs:label xml:lang="en">VehicleComponent</rdfs:label>
@@ -326,8 +326,8 @@ and [VehicleProperties](#https://github.com/w3c/vsso#VehicleProperty) belonging 
 
     <owl:Class rdf:about="https://github.com/w3c/vsso#VehicleProperty">
         <rdfs:comment xml:lang="en">_VehicleProperty_ - Central concept for defining a vehicle, either through a VehicleComponent structure
-or connected directly to the vehicle. Every VehicleProperty shall be instantiated with a [vehiclePropertyValue](#https://github.com/w3c/vsso#vehiclePropertyValue).
-It is good practice to set the time when the value was updated through [valueUpdatedAt](#https://github.com/w3c/vsso#valueUpdatedAt)
+or connected directly to the vehicle. Every VehicleProperty shall be instantiated with a [vehiclePropertyValue](#vehiclePropertyValue).
+It is good practice to set the time when the value was updated through [propertyValueUpdatedAt](#propertyValueUpdatedAt)
 The VehicleProperty follows the concept of a [ssn:Property](https://www.w3.org/TR/vocab-ssn/#SSNProperty)</rdfs:comment>
         <rdfs:label xml:lang="en">VehicleProperty</rdfs:label>
         <rdfs:seeAlso>https://www.w3.org/TR/vocab-ssn/#SSNProperty</rdfs:seeAlso>

--- a/vsso-core/docs/ontology.rdf
+++ b/vsso-core/docs/ontology.rdf
@@ -261,12 +261,12 @@ this property is expected to change frequently, even within a vehicle lifecycle.
 
     <owl:Class rdf:about="https://github.com/w3c/vsso#ObservableVehicleProperty">
         <rdfs:subClassOf rdf:resource="https://github.com/w3c/vsso#DynamicVehicleProperty"/>
-        <rdfs:comment xml:lang="en">_ObservableVehicleProperty_ - Follows the definition of an [actuator](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/) in
+        <rdfs:comment xml:lang="en">_ObservableVehicleProperty_ - Follows the definition of an [sensor](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/) in
 VSS. It is a [DynamicVehicleProperty](#https://github.com/w3c/vsso#DynamicVehicleProperty), which can be observed but _not_ changed.
 Refers to [sosa:ObservableProperty](https://www.w3.org/TR/vocab-ssn/#SOSAObservableProperty)</rdfs:comment>
         <rdfs:label xml:lang="en">ObservableVehicleProperty</rdfs:label>
+        <rdfs:seeAlso>https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/</rdfs:seeAlso>
         <rdfs:seeAlso>https://www.w3.org/TR/vocab-ssn/#SOSAObservableProperty</rdfs:seeAlso>
-        <rdfs:seeAlso>ttps://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/</rdfs:seeAlso>
     </owl:Class>
     
 

--- a/vsso-core/docs/ontology.ttl
+++ b/vsso-core/docs/ontology.ttl
@@ -138,7 +138,7 @@ StaticVehicleComponent."""@en ;
 :ActuatableVehicleProperty rdf:type owl:Class ;
                            rdfs:subClassOf :DynamicVehicleProperty ;
                            rdfs:comment """_ActuatableVehicleProperty_ - Follows the definition of an [actuator](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/) in
-VSS. It is a [DynamicVehicleProperty](#https://github.com/w3c/vsso#DynamicVehicleProperty), which can be changed.
+VSS. It is a [DynamicVehicleProperty](#DynamicVehicleProperty), which can be changed.
 Refers to [sosa:ActuableProperty](https://www.w3.org/TR/vocab-ssn/#SOSAActuatableProperty)"""@en ;
                            rdfs:label "ActuatableVehicleProperty"@en ;
                            rdfs:seeAlso "https://www.w3.org/TR/vocab-ssn/#SOSAActuatableProperty" ,
@@ -148,8 +148,8 @@ Refers to [sosa:ActuableProperty](https://www.w3.org/TR/vocab-ssn/#SOSAActuatabl
 ###  https://github.com/w3c/vsso#DynamicVehicleProperty
 :DynamicVehicleProperty rdf:type owl:Class ;
                         rdfs:subClassOf :VehicleProperty ;
-                        rdfs:comment """_DynamicVehicleProperty_ - In contrast to a [StaticVehicleProperty](#https://github.com/w3c/vsso#StaticVehicleProperty),
-this property is expected to change frequently, even within a vehicle lifecycle. Examples are the vehicle `speed`, `location`, etc."""@en ;
+                        rdfs:comment """_DynamicVehicleProperty_ - In contrast to a [StaticVehicleProperty](#StaticVehicleProperty),
+this property is expected to change frequently, even within an ignition cycle. Examples are the vehicle `speed`, `location`, etc."""@en ;
                         rdfs:label "DynamicVehicleProperty"@en .
 
 
@@ -157,7 +157,7 @@ this property is expected to change frequently, even within a vehicle lifecycle.
 :ObservableVehicleProperty rdf:type owl:Class ;
                            rdfs:subClassOf :DynamicVehicleProperty ;
                            rdfs:comment """_ObservableVehicleProperty_ - Follows the definition of an [sensor](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/) in
-VSS. It is a [DynamicVehicleProperty](#https://github.com/w3c/vsso#DynamicVehicleProperty), which can be observed but _not_ changed.
+VSS. It is a [DynamicVehicleProperty](#DynamicVehicleProperty), which can be observed but _not_ changed.
 Refers to [sosa:ObservableProperty](https://www.w3.org/TR/vocab-ssn/#SOSAObservableProperty)"""@en ;
                            rdfs:label "ObservableVehicleProperty"@en ;
                            rdfs:seeAlso "https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/" ,
@@ -176,22 +176,22 @@ They can be named with the positionName property."""@en ;
 :StaticVehicleProperty rdf:type owl:Class ;
                        rdfs:subClassOf :VehicleProperty ;
                        rdfs:comment """_StaticVehicleProperty_ - Follows the definition of an [attribute](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/attributes/) in
-VSS. `StaticVehicleProperty` is meant to stay stable at least over the duration of a vehicle lifecycle.
-If you expect more frequent updates, please consider [DynamicVehicleProperty](#https://github.com/w3c/vsso#DynamicVehicleProperty)"""@en ;
+VSS. `StaticVehicleProperty` is meant to stay stable at least over the duration of an ignition cycle.
+If you expect more frequent updates, please consider [DynamicVehicleProperty](#DynamicVehicleProperty)"""@en ;
                        rdfs:label "StaticVehicleProperty"@en ;
                        rdfs:seeAlso "https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/attributes/" .
 
 
 ###  https://github.com/w3c/vsso#Vehicle
 :Vehicle rdf:type owl:Class ;
-         rdfs:comment """_Vehicle_ - Core concept of the ontology. Collects [VehicleComponents](#https://github.com/w3c/vsso#VehicleComponent)
-and [VehicleProperties](#https://github.com/w3c/vsso#VehicleProperty) belonging to a vehicle"""@en ;
+         rdfs:comment """_Vehicle_ - Core concept of the ontology. Collects [VehicleComponents](#VehicleComponent)
+and [VehicleProperties](#VehicleProperty) belonging to a vehicle"""@en ;
          rdfs:label "Vehicle"@en .
 
 
 ###  https://github.com/w3c/vsso#VehicleComponent
 :VehicleComponent rdf:type owl:Class ;
-                  rdfs:comment """_VehicleComponent_ - First of all a sorting element for [VehicleProperties](#https://github.com/w3c/vsso#VehicleProperty), following on the definition of a
+                  rdfs:comment """_VehicleComponent_ - First of all a sorting element for [VehicleProperties](#VehicleProperty), following on the definition of a
 [branch](https://covesa.github.io/vehicle_signal_specification/rule_set/branches/). It is encouraged to use the concept for actual parts modeled as
 `VehicleComponent."""@en ;
                   rdfs:label "VehicleComponent"@en ;
@@ -201,8 +201,8 @@ and [VehicleProperties](#https://github.com/w3c/vsso#VehicleProperty) belonging 
 ###  https://github.com/w3c/vsso#VehicleProperty
 :VehicleProperty rdf:type owl:Class ;
                  rdfs:comment """_VehicleProperty_ - Central concept for defining a vehicle, either through a VehicleComponent structure
-or connected directly to the vehicle. Every VehicleProperty shall be instantiated with a [vehiclePropertyValue](#https://github.com/w3c/vsso#vehiclePropertyValue).
-It is good practice to set the time when the value was updated through [valueUpdatedAt](#https://github.com/w3c/vsso#valueUpdatedAt)
+or connected directly to the vehicle. Every VehicleProperty shall be instantiated with a [vehiclePropertyValue](#vehiclePropertyValue).
+It is good practice to set the time when the value was updated through [propertyValueUpdatedAt](#propertyValueUpdatedAt)
 The VehicleProperty follows the concept of a [ssn:Property](https://www.w3.org/TR/vocab-ssn/#SSNProperty)"""@en ;
                  rdfs:label "VehicleProperty"@en ;
                  rdfs:seeAlso "https://www.w3.org/TR/vocab-ssn/#SSNProperty" .

--- a/vsso-core/docs/ontology.ttl
+++ b/vsso-core/docs/ontology.ttl
@@ -156,12 +156,12 @@ this property is expected to change frequently, even within a vehicle lifecycle.
 ###  https://github.com/w3c/vsso#ObservableVehicleProperty
 :ObservableVehicleProperty rdf:type owl:Class ;
                            rdfs:subClassOf :DynamicVehicleProperty ;
-                           rdfs:comment """_ObservableVehicleProperty_ - Follows the definition of an [actuator](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/) in
+                           rdfs:comment """_ObservableVehicleProperty_ - Follows the definition of an [sensor](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/) in
 VSS. It is a [DynamicVehicleProperty](#https://github.com/w3c/vsso#DynamicVehicleProperty), which can be observed but _not_ changed.
 Refers to [sosa:ObservableProperty](https://www.w3.org/TR/vocab-ssn/#SOSAObservableProperty)"""@en ;
                            rdfs:label "ObservableVehicleProperty"@en ;
-                           rdfs:seeAlso "https://www.w3.org/TR/vocab-ssn/#SOSAObservableProperty" ,
-                                        "ttps://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/" .
+                           rdfs:seeAlso "https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/" ,
+                                        "https://www.w3.org/TR/vocab-ssn/#SOSAObservableProperty" .
 
 
 ###  https://github.com/w3c/vsso#PositionInVehicle

--- a/vsso-core/docs/sections/crossref-en.html
+++ b/vsso-core/docs/sections/crossref-en.html
@@ -94,7 +94,7 @@ this property is expected to change frequently, even within a vehicle lifecycle.
       <p>
          <strong>IRI:</strong> https://github.com/w3c/vsso#ObservableVehicleProperty</p>
       <div class="comment">
-         <span class="markdown">_ObservableVehicleProperty_ - Follows the definition of an [actuator](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/) in
+         <span class="markdown">_ObservableVehicleProperty_ - Follows the definition of an [sensor](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/) in
 VSS. It is a [DynamicVehicleProperty](#https://github.com/w3c/vsso#DynamicVehicleProperty), which can be observed but _not_ changed.
 Refers to [sosa:ObservableProperty](https://www.w3.org/TR/vocab-ssn/#SOSAObservableProperty)</span>
       </div>

--- a/vsso-core/docs/sections/crossref-en.html
+++ b/vsso-core/docs/sections/crossref-en.html
@@ -41,7 +41,7 @@ This section provides details for each class and property defined by VSSo Core: 
          <strong>IRI:</strong> https://github.com/w3c/vsso#ActuatableVehicleProperty</p>
       <div class="comment">
          <span class="markdown">_ActuatableVehicleProperty_ - Follows the definition of an [actuator](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/) in
-VSS. It is a [DynamicVehicleProperty](#https://github.com/w3c/vsso#DynamicVehicleProperty), which can be changed.
+VSS. It is a [DynamicVehicleProperty](#DynamicVehicleProperty), which can be changed.
 Refers to [sosa:ActuableProperty](https://www.w3.org/TR/vocab-ssn/#SOSAActuatableProperty)</span>
       </div>
       <dl class="description">
@@ -61,8 +61,8 @@ Refers to [sosa:ActuableProperty](https://www.w3.org/TR/vocab-ssn/#SOSAActuatabl
       <p>
          <strong>IRI:</strong> https://github.com/w3c/vsso#DynamicVehicleProperty</p>
       <div class="comment">
-         <span class="markdown">_DynamicVehicleProperty_ - In contrast to a [StaticVehicleProperty](#https://github.com/w3c/vsso#StaticVehicleProperty),
-this property is expected to change frequently, even within a vehicle lifecycle. Examples are the vehicle `speed`, `location`, etc.</span>
+         <span class="markdown">_DynamicVehicleProperty_ - In contrast to a [StaticVehicleProperty](#StaticVehicleProperty),
+this property is expected to change frequently, even within an ignition cycle. Examples are the vehicle `speed`, `location`, etc.</span>
       </div>
       <dl class="description">
          <dt>has super-classes</dt>
@@ -95,7 +95,7 @@ this property is expected to change frequently, even within a vehicle lifecycle.
          <strong>IRI:</strong> https://github.com/w3c/vsso#ObservableVehicleProperty</p>
       <div class="comment">
          <span class="markdown">_ObservableVehicleProperty_ - Follows the definition of an [sensor](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/) in
-VSS. It is a [DynamicVehicleProperty](#https://github.com/w3c/vsso#DynamicVehicleProperty), which can be observed but _not_ changed.
+VSS. It is a [DynamicVehicleProperty](#DynamicVehicleProperty), which can be observed but _not_ changed.
 Refers to [sosa:ObservableProperty](https://www.w3.org/TR/vocab-ssn/#SOSAObservableProperty)</span>
       </div>
       <dl class="description">
@@ -141,8 +141,8 @@ They can be named with the positionName property.</span>
          <strong>IRI:</strong> https://github.com/w3c/vsso#StaticVehicleProperty</p>
       <div class="comment">
          <span class="markdown">_StaticVehicleProperty_ - Follows the definition of an [attribute](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/attributes/) in
-VSS. `StaticVehicleProperty` is meant to stay stable at least over the duration of a vehicle lifecycle.
-If you expect more frequent updates, please consider [DynamicVehicleProperty](#https://github.com/w3c/vsso#DynamicVehicleProperty)</span>
+VSS. `StaticVehicleProperty` is meant to stay stable at least over the duration of an ignition cycle.
+If you expect more frequent updates, please consider [DynamicVehicleProperty](#DynamicVehicleProperty)</span>
       </div>
       <dl class="description">
          <dt>has super-classes</dt>
@@ -166,8 +166,8 @@ If you expect more frequent updates, please consider [DynamicVehicleProperty](#h
       <p>
          <strong>IRI:</strong> https://github.com/w3c/vsso#Vehicle</p>
       <div class="comment">
-         <span class="markdown">_Vehicle_ - Core concept of the ontology. Collects [VehicleComponents](#https://github.com/w3c/vsso#VehicleComponent)
-and [VehicleProperties](#https://github.com/w3c/vsso#VehicleProperty) belonging to a vehicle</span>
+         <span class="markdown">_Vehicle_ - Core concept of the ontology. Collects [VehicleComponents](#VehicleComponent)
+and [VehicleProperties](#VehicleProperty) belonging to a vehicle</span>
       </div>
       <dl class="description">
          <dt>is in range of</dt>
@@ -185,7 +185,7 @@ and [VehicleProperties](#https://github.com/w3c/vsso#VehicleProperty) belonging 
       <p>
          <strong>IRI:</strong> https://github.com/w3c/vsso#VehicleComponent</p>
       <div class="comment">
-         <span class="markdown">_VehicleComponent_ - First of all a sorting element for [VehicleProperties](#https://github.com/w3c/vsso#VehicleProperty), following on the definition of a
+         <span class="markdown">_VehicleComponent_ - First of all a sorting element for [VehicleProperties](#VehicleProperty), following on the definition of a
 [branch](https://covesa.github.io/vehicle_signal_specification/rule_set/branches/). It is encouraged to use the concept for actual parts modeled as
 `VehicleComponent.</span>
       </div>
@@ -214,8 +214,8 @@ and [VehicleProperties](#https://github.com/w3c/vsso#VehicleProperty) belonging 
          <strong>IRI:</strong> https://github.com/w3c/vsso#VehicleProperty</p>
       <div class="comment">
          <span class="markdown">_VehicleProperty_ - Central concept for defining a vehicle, either through a VehicleComponent structure
-or connected directly to the vehicle. Every VehicleProperty shall be instantiated with a [vehiclePropertyValue](#https://github.com/w3c/vsso#vehiclePropertyValue).
-It is good practice to set the time when the value was updated through [valueUpdatedAt](#https://github.com/w3c/vsso#valueUpdatedAt)
+or connected directly to the vehicle. Every VehicleProperty shall be instantiated with a [vehiclePropertyValue](#vehiclePropertyValue).
+It is good practice to set the time when the value was updated through [propertyValueUpdatedAt](#propertyValueUpdatedAt)
 The VehicleProperty follows the concept of a [ssn:Property](https://www.w3.org/TR/vocab-ssn/#SSNProperty)</span>
       </div>
       <dl class="description">

--- a/vsso-core/docs/webvowl/data/ontology.json
+++ b/vsso-core/docs/webvowl/data/ontology.json
@@ -27,12 +27,12 @@
       }, {
         "identifier" : "creator",
         "language" : "undefined",
-        "value" : "Benjamin Klotz",
+        "value" : "Raphael Troncy",
         "type" : "label"
       }, {
         "identifier" : "creator",
         "language" : "undefined",
-        "value" : "Raphael Troncy",
+        "value" : "Benjamin Klotz",
         "type" : "label"
       } ],
       "contributor" : [ {
@@ -298,7 +298,7 @@
       "seeAlso" : [ {
         "identifier" : "seeAlso",
         "language" : "undefined",
-        "value" : "ttps://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/",
+        "value" : "https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/",
         "type" : "label"
       }, {
         "identifier" : "seeAlso",
@@ -312,7 +312,7 @@
       "en" : "ObservableVehicleProperty"
     },
     "comment" : {
-      "en" : "_ObservableVehicleProperty_ - Follows the definition of an [actuator](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/) in\nVSS. It is a [DynamicVehicleProperty](#https://github.com/w3c/vsso#DynamicVehicleProperty), which can be observed but _not_ changed.\nRefers to [sosa:ObservableProperty](https://www.w3.org/TR/vocab-ssn/#SOSAObservableProperty)"
+      "en" : "_ObservableVehicleProperty_ - Follows the definition of an [sensor](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/) in\nVSS. It is a [DynamicVehicleProperty](#https://github.com/w3c/vsso#DynamicVehicleProperty), which can be observed but _not_ changed.\nRefers to [sosa:ObservableProperty](https://www.w3.org/TR/vocab-ssn/#SOSAObservableProperty)"
     },
     "id" : "4",
     "superClasses" : [ "3" ]
@@ -402,17 +402,17 @@
   }, {
     "range" : "3",
     "domain" : "4",
-    "attributes" : [ "object", "anonymous" ],
+    "attributes" : [ "anonymous", "object" ],
     "id" : "13"
   }, {
     "range" : "3",
     "domain" : "5",
-    "attributes" : [ "object", "anonymous" ],
+    "attributes" : [ "anonymous", "object" ],
     "id" : "14"
   }, {
     "range" : "1",
     "domain" : "3",
-    "attributes" : [ "object", "anonymous" ],
+    "attributes" : [ "anonymous", "object" ],
     "id" : "15"
   }, {
     "iri" : "https://github.com/w3c/vsso#positionName",
@@ -431,7 +431,7 @@
   }, {
     "range" : "1",
     "domain" : "19",
-    "attributes" : [ "object", "anonymous" ],
+    "attributes" : [ "anonymous", "object" ],
     "id" : "18"
   }, {
     "iri" : "https://github.com/w3c/vsso#postionedAt",

--- a/vsso-core/docs/webvowl/data/ontology.json
+++ b/vsso-core/docs/webvowl/data/ontology.json
@@ -22,12 +22,12 @@
       "creator" : [ {
         "identifier" : "creator",
         "language" : "undefined",
-        "value" : "Daniel Wilms",
+        "value" : "Raphael Troncy",
         "type" : "label"
       }, {
         "identifier" : "creator",
         "language" : "undefined",
-        "value" : "Raphael Troncy",
+        "value" : "Daniel Wilms",
         "type" : "label"
       }, {
         "identifier" : "creator",
@@ -38,12 +38,12 @@
       "contributor" : [ {
         "identifier" : "contributor",
         "language" : "undefined",
-        "value" : "Felix Loesch",
+        "value" : "Daniel Alvarez-Coello",
         "type" : "label"
       }, {
         "identifier" : "contributor",
         "language" : "undefined",
-        "value" : "Daniel Alvarez-Coello",
+        "value" : "Felix Loesch",
         "type" : "label"
       } ],
       "preferredNamespacePrefix" : [ {
@@ -52,16 +52,16 @@
         "value" : "vsso-core",
         "type" : "label"
       } ],
-      "preferredNamespaceUri" : [ {
-        "identifier" : "preferredNamespaceUri",
-        "language" : "undefined",
-        "value" : "https://github.com/w3c/vsso#",
-        "type" : "label"
-      } ],
       "versionInfo" : [ {
         "identifier" : "versionInfo",
         "language" : "en",
         "value" : "v2.0-develop",
+        "type" : "label"
+      } ],
+      "preferredNamespaceUri" : [ {
+        "identifier" : "preferredNamespaceUri",
+        "language" : "undefined",
+        "value" : "https://github.com/w3c/vsso#",
         "type" : "label"
       } ],
       "title" : [ {
@@ -132,7 +132,7 @@
     },
     "subClasses" : [ "4", "5" ],
     "comment" : {
-      "en" : "_DynamicVehicleProperty_ - In contrast to a [StaticVehicleProperty](#https://github.com/w3c/vsso#StaticVehicleProperty),\nthis property is expected to change frequently, even within a vehicle lifecycle. Examples are the vehicle `speed`, `location`, etc."
+      "en" : "_DynamicVehicleProperty_ - In contrast to a [StaticVehicleProperty](#StaticVehicleProperty),\nthis property is expected to change frequently, even within an ignition cycle. Examples are the vehicle `speed`, `location`, etc."
     },
     "id" : "3",
     "superClasses" : [ "1" ]
@@ -205,7 +205,7 @@
       "en" : "ActuatableVehicleProperty"
     },
     "comment" : {
-      "en" : "_ActuatableVehicleProperty_ - Follows the definition of an [actuator](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/) in\nVSS. It is a [DynamicVehicleProperty](#https://github.com/w3c/vsso#DynamicVehicleProperty), which can be changed.\nRefers to [sosa:ActuableProperty](https://www.w3.org/TR/vocab-ssn/#SOSAActuatableProperty)"
+      "en" : "_ActuatableVehicleProperty_ - Follows the definition of an [actuator](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/) in\nVSS. It is a [DynamicVehicleProperty](#DynamicVehicleProperty), which can be changed.\nRefers to [sosa:ActuableProperty](https://www.w3.org/TR/vocab-ssn/#SOSAActuatableProperty)"
     },
     "id" : "5",
     "superClasses" : [ "3" ]
@@ -234,7 +234,7 @@
     },
     "subClasses" : [ "3", "19" ],
     "comment" : {
-      "en" : "_VehicleProperty_ - Central concept for defining a vehicle, either through a VehicleComponent structure\nor connected directly to the vehicle. Every VehicleProperty shall be instantiated with a [vehiclePropertyValue](#https://github.com/w3c/vsso#vehiclePropertyValue).\nIt is good practice to set the time when the value was updated through [valueUpdatedAt](#https://github.com/w3c/vsso#valueUpdatedAt)\nThe VehicleProperty follows the concept of a [ssn:Property](https://www.w3.org/TR/vocab-ssn/#SSNProperty)"
+      "en" : "_VehicleProperty_ - Central concept for defining a vehicle, either through a VehicleComponent structure\nor connected directly to the vehicle. Every VehicleProperty shall be instantiated with a [vehiclePropertyValue](#vehiclePropertyValue).\nIt is good practice to set the time when the value was updated through [propertyValueUpdatedAt](#propertyValueUpdatedAt)\nThe VehicleProperty follows the concept of a [ssn:Property](https://www.w3.org/TR/vocab-ssn/#SSNProperty)"
     },
     "id" : "1"
   }, {
@@ -254,7 +254,7 @@
       "en" : "VehicleComponent"
     },
     "comment" : {
-      "en" : "_VehicleComponent_ - First of all a sorting element for [VehicleProperties](#https://github.com/w3c/vsso#VehicleProperty), following on the definition of a\n[branch](https://covesa.github.io/vehicle_signal_specification/rule_set/branches/). It is encouraged to use the concept for actual parts modeled as\n`VehicleComponent."
+      "en" : "_VehicleComponent_ - First of all a sorting element for [VehicleProperties](#VehicleProperty), following on the definition of a\n[branch](https://covesa.github.io/vehicle_signal_specification/rule_set/branches/). It is encouraged to use the concept for actual parts modeled as\n`VehicleComponent."
     },
     "id" : "2"
   }, {
@@ -266,7 +266,7 @@
       "en" : "Vehicle"
     },
     "comment" : {
-      "en" : "_Vehicle_ - Core concept of the ontology. Collects [VehicleComponents](#https://github.com/w3c/vsso#VehicleComponent)\nand [VehicleProperties](#https://github.com/w3c/vsso#VehicleProperty) belonging to a vehicle"
+      "en" : "_Vehicle_ - Core concept of the ontology. Collects [VehicleComponents](#VehicleComponent)\nand [VehicleProperties](#VehicleProperty) belonging to a vehicle"
     },
     "id" : "23"
   }, {
@@ -286,7 +286,7 @@
       "en" : "StaticVehicleProperty"
     },
     "comment" : {
-      "en" : "_StaticVehicleProperty_ - Follows the definition of an [attribute](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/attributes/) in\nVSS. `StaticVehicleProperty` is meant to stay stable at least over the duration of a vehicle lifecycle.\nIf you expect more frequent updates, please consider [DynamicVehicleProperty](#https://github.com/w3c/vsso#DynamicVehicleProperty)"
+      "en" : "_StaticVehicleProperty_ - Follows the definition of an [attribute](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/attributes/) in\nVSS. `StaticVehicleProperty` is meant to stay stable at least over the duration of an ignition cycle.\nIf you expect more frequent updates, please consider [DynamicVehicleProperty](#DynamicVehicleProperty)"
     },
     "id" : "19",
     "superClasses" : [ "1" ]
@@ -312,7 +312,7 @@
       "en" : "ObservableVehicleProperty"
     },
     "comment" : {
-      "en" : "_ObservableVehicleProperty_ - Follows the definition of an [sensor](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/) in\nVSS. It is a [DynamicVehicleProperty](#https://github.com/w3c/vsso#DynamicVehicleProperty), which can be observed but _not_ changed.\nRefers to [sosa:ObservableProperty](https://www.w3.org/TR/vocab-ssn/#SOSAObservableProperty)"
+      "en" : "_ObservableVehicleProperty_ - Follows the definition of an [sensor](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/) in\nVSS. It is a [DynamicVehicleProperty](#DynamicVehicleProperty), which can be observed but _not_ changed.\nRefers to [sosa:ObservableProperty](https://www.w3.org/TR/vocab-ssn/#SOSAObservableProperty)"
     },
     "id" : "4",
     "superClasses" : [ "3" ]
@@ -462,20 +462,6 @@
     "attributes" : [ "object" ],
     "id" : "22"
   }, {
-    "iri" : "https://github.com/w3c/vsso#hasDynamicVehicleProperty",
-    "baseIri" : "https://github.com/w3c/vsso",
-    "range" : "3",
-    "label" : {
-      "IRI-based" : "hasDynamicVehicleProperty",
-      "en" : "hasDynamicVehicleProperty"
-    },
-    "domain" : "10",
-    "comment" : {
-      "en" : "_hasDynamicVehicleProperty_ - This property connects an instance of a Vehicle or VehicleComponent to a \nDynamicVehicleComponent."
-    },
-    "attributes" : [ "object" ],
-    "id" : "24"
-  }, {
     "iri" : "https://github.com/w3c/vsso#partOfVehicle",
     "baseIri" : "https://github.com/w3c/vsso",
     "range" : "23",
@@ -486,6 +472,20 @@
     "domain" : "2",
     "comment" : {
       "en" : "_partOfVehicle_ - This properties conncects VehicleComponents instances with an instance of a Vehicle."
+    },
+    "attributes" : [ "object" ],
+    "id" : "24"
+  }, {
+    "iri" : "https://github.com/w3c/vsso#hasDynamicVehicleProperty",
+    "baseIri" : "https://github.com/w3c/vsso",
+    "range" : "3",
+    "label" : {
+      "IRI-based" : "hasDynamicVehicleProperty",
+      "en" : "hasDynamicVehicleProperty"
+    },
+    "domain" : "10",
+    "comment" : {
+      "en" : "_hasDynamicVehicleProperty_ - This property connects an instance of a Vehicle or VehicleComponent to a \nDynamicVehicleComponent."
     },
     "attributes" : [ "object" ],
     "id" : "25"

--- a/vsso-core/vsso-core.ttl
+++ b/vsso-core/vsso-core.ttl
@@ -63,10 +63,10 @@ Refers to [sosa:ActuableProperty](https://www.w3.org/TR/vocab-ssn/#SOSAActuatabl
 vsso-core:ObservableVehicleProperty a owl:Class ;
     rdfs:label "ObservableVehicleProperty"@en ;
     rdfs:subClassOf vsso-core:DynamicVehicleProperty ;
-    rdfs:comment "_ObservableVehicleProperty_ - Follows the definition of an [actuator](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/) in
+    rdfs:comment "_ObservableVehicleProperty_ - Follows the definition of an [sensor](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/) in
 VSS. It is a [DynamicVehicleProperty](#https://github.com/w3c/vsso#DynamicVehicleProperty), which can be observed but _not_ changed.
 Refers to [sosa:ObservableProperty](https://www.w3.org/TR/vocab-ssn/#SOSAObservableProperty)"@en ;
-    rdfs:seeAlso "ttps://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/" ;
+    rdfs:seeAlso "https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/" ;
     rdfs:seeAlso "https://www.w3.org/TR/vocab-ssn/#SOSAObservableProperty" .
 
 vsso-core:DynamicVehicleProperty a owl:Class ;

--- a/vsso-core/vsso-core.ttl
+++ b/vsso-core/vsso-core.ttl
@@ -26,8 +26,8 @@ vsso-core: rdf:type owl:Ontology ;
 vsso-core:VehicleProperty a owl:Class ;
     rdfs:label "VehicleProperty"@en ;
     rdfs:comment "_VehicleProperty_ - Central concept for defining a vehicle, either through a VehicleComponent structure
-or connected directly to the vehicle. Every VehicleProperty shall be instantiated with a [vehiclePropertyValue](#https://github.com/w3c/vsso#vehiclePropertyValue).
-It is good practice to set the time when the value was updated through [valueUpdatedAt](#https://github.com/w3c/vsso#valueUpdatedAt)
+or connected directly to the vehicle. Every VehicleProperty shall be instantiated with a [vehiclePropertyValue](#vehiclePropertyValue).
+It is good practice to set the time when the value was updated through [propertyValueUpdatedAt](#propertyValueUpdatedAt)
 The VehicleProperty follows the concept of a [ssn:Property](https://www.w3.org/TR/vocab-ssn/#SSNProperty)"@en ;
     rdfs:seeAlso "https://www.w3.org/TR/vocab-ssn/#SSNProperty" .
 
@@ -35,18 +35,18 @@ vsso-core:StaticVehicleProperty a owl:Class ;
     rdfs:subClassOf vsso-core:VehicleProperty ;
     rdfs:label "StaticVehicleProperty"@en ;
     rdfs:comment "_StaticVehicleProperty_ - Follows the definition of an [attribute](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/attributes/) in
-VSS. `StaticVehicleProperty` is meant to stay stable at least over the duration of a vehicle lifecycle.
-If you expect more frequent updates, please consider [DynamicVehicleProperty](#https://github.com/w3c/vsso#DynamicVehicleProperty)"@en ;
+VSS. `StaticVehicleProperty` is meant to stay stable at least over the duration of an ignition cycle.
+If you expect more frequent updates, please consider [DynamicVehicleProperty](#DynamicVehicleProperty)"@en ;
     rdfs:seeAlso "https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/attributes/".
 
 vsso-core:Vehicle a owl:Class ;
     rdfs:label "Vehicle"@en ;
-    rdfs:comment "_Vehicle_ - Core concept of the ontology. Collects [VehicleComponents](#https://github.com/w3c/vsso#VehicleComponent)
-and [VehicleProperties](#https://github.com/w3c/vsso#VehicleProperty) belonging to a vehicle"@en .
+    rdfs:comment "_Vehicle_ - Core concept of the ontology. Collects [VehicleComponents](#VehicleComponent)
+and [VehicleProperties](#VehicleProperty) belonging to a vehicle"@en .
 
 vsso-core:VehicleComponent a owl:Class ;
     rdfs:label "VehicleComponent"@en ;
-    rdfs:comment "_VehicleComponent_ - First of all a sorting element for [VehicleProperties](#https://github.com/w3c/vsso#VehicleProperty), following on the definition of a
+    rdfs:comment "_VehicleComponent_ - First of all a sorting element for [VehicleProperties](#VehicleProperty), following on the definition of a
 [branch](https://covesa.github.io/vehicle_signal_specification/rule_set/branches/). It is encouraged to use the concept for actual parts modeled as
 `VehicleComponent."@en ;
     rdfs:seeAlso "https://covesa.github.io/vehicle_signal_specification/rule_set/branches/".
@@ -55,7 +55,7 @@ vsso-core:ActuatableVehicleProperty a owl:Class ;
     rdfs:label "ActuatableVehicleProperty"@en ;
     rdfs:subClassOf vsso-core:DynamicVehicleProperty ;
     rdfs:comment "_ActuatableVehicleProperty_ - Follows the definition of an [actuator](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/) in
-VSS. It is a [DynamicVehicleProperty](#https://github.com/w3c/vsso#DynamicVehicleProperty), which can be changed.
+VSS. It is a [DynamicVehicleProperty](#DynamicVehicleProperty), which can be changed.
 Refers to [sosa:ActuableProperty](https://www.w3.org/TR/vocab-ssn/#SOSAActuatableProperty)"@en ;
     rdfs:seeAlso "ttps://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/" ;
     rdfs:seeAlso "https://www.w3.org/TR/vocab-ssn/#SOSAActuatableProperty" .
@@ -64,7 +64,7 @@ vsso-core:ObservableVehicleProperty a owl:Class ;
     rdfs:label "ObservableVehicleProperty"@en ;
     rdfs:subClassOf vsso-core:DynamicVehicleProperty ;
     rdfs:comment "_ObservableVehicleProperty_ - Follows the definition of an [sensor](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/) in
-VSS. It is a [DynamicVehicleProperty](#https://github.com/w3c/vsso#DynamicVehicleProperty), which can be observed but _not_ changed.
+VSS. It is a [DynamicVehicleProperty](#DynamicVehicleProperty), which can be observed but _not_ changed.
 Refers to [sosa:ObservableProperty](https://www.w3.org/TR/vocab-ssn/#SOSAObservableProperty)"@en ;
     rdfs:seeAlso "https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/" ;
     rdfs:seeAlso "https://www.w3.org/TR/vocab-ssn/#SOSAObservableProperty" .
@@ -72,8 +72,8 @@ Refers to [sosa:ObservableProperty](https://www.w3.org/TR/vocab-ssn/#SOSAObserva
 vsso-core:DynamicVehicleProperty a owl:Class ;
     rdfs:subClassOf vsso-core:VehicleProperty ;
     rdfs:label "DynamicVehicleProperty"@en ;
-    rdfs:comment "_DynamicVehicleProperty_ - In contrast to a [StaticVehicleProperty](#https://github.com/w3c/vsso#StaticVehicleProperty),
-this property is expected to change frequently, even within a vehicle lifecycle. Examples are the vehicle `speed`, `location`, etc."@en .
+    rdfs:comment "_DynamicVehicleProperty_ - In contrast to a [StaticVehicleProperty](#StaticVehicleProperty),
+this property is expected to change frequently, even within an ignition cycle. Examples are the vehicle `speed`, `location`, etc."@en .
 
 vsso-core:PositionInVehicle a owl:Class;
     rdfs:label "PositionInVehicle"@en ;


### PR DESCRIPTION
As stated in #19 the metadata of ObservableVehicleProperty was incorrect:
* referred to VSS `actuator` instead of `sensor`
* `seeAlso` link was broken

This commit fixes it. Some changes are due to the generated code. Once #18 is fixed, no need to check it in.

Signed-off-by: Daniel Wilms <Daniel.DW.Wilms@bmw.de>