### PR TITLE
Updated vsso [instances, annotation]

### DIFF
--- a/spec/vss_rel_2.2.ttl
+++ b/spec/vss_rel_2.2.ttl
@@ -17,7 +17,7 @@ vsso: a owl:Ontology ;
     dcterms:contributor "Daniel Alvarez-Coello"^^xsd:string,
         "Felix Loesch"^^xsd:string ;
     dcterms:creator "Benjamin Klotz"^^xsd:string,
-        "Daniel Wilms",
+        "Daniel Wilms"^^xsd:string,
         "Raphael Troncy"^^xsd:string ;
     dcterms:description "This ontology describes the car's attributes, branches and signals defined in the Vehicle Signal Specification." ;
     dcterms:license <http://creativecommons.org/licenses/by/4.0/> ;
@@ -27,4690 +27,3382 @@ vsso: a owl:Ontology ;
     rdfs:seeAlso "https://github.com/COVESA/vehicle_signal_specification" ;
     owl:versionInfo "v2.2"@en .
 
-vsso:ABSError a owl:Class ;
+vsso:ABSError a vsso-core:ObservableVehicleProperty ;
     rdfs:label "ABSError"@en ;
-    rdfs:comment "Indicates if ABS incurred an error condition. True = Error. False = No Error."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ADASABS ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.ADAS.ABS.Error"@en .
+    skos:definition "Indicates if ABS incurred an error condition. True = Error. False = No Error."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.ADAS.ABS.Error"@en .
 
-vsso:ABSIsActive a owl:Class ;
+vsso:ABSIsActive a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
     rdfs:label "ABSIsActive"@en ;
-    rdfs:comment "Indicates if ABS is enabled. True = Enabled. False = Disabled."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ADASABS ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.ADAS.ABS.IsActive"@en .
+    skos:definition "Indicates if ABS is enabled. True = Enabled. False = Disabled."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.ADAS.ABS.IsActive"@en .
 
-vsso:ABSIsEngaged a owl:Class ;
+vsso:ABSIsEngaged a vsso-core:ObservableVehicleProperty ;
     rdfs:label "ABSIsEngaged"@en ;
-    rdfs:comment "Indicates if ABS is currently regulating brake pressure. True = Engaged. False = Not Engaged."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ADASABS ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.ADAS.ABS.IsEngaged"@en .
+    skos:definition "Indicates if ABS is currently regulating brake pressure. True = Engaged. False = Not Engaged."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.ADAS.ABS.IsEngaged"@en .
 
-vsso:AccelerationLateral a owl:Class ;
+vsso:ADASABS a owl:Class ;
+    rdfs:label "ADASABS"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:ADAS ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Antilock Braking System signals"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.ADAS.ABS"@en .
+
+vsso:ADASCruiseControl a owl:Class ;
+    rdfs:label "ADASCruiseControl"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:ADAS ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Signals from Cruise Control system"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.ADAS.CruiseControl"@en .
+
+vsso:ADASESC a owl:Class ;
+    rdfs:label "ADASESC"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:ADAS ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Electronic Stability Control System signals"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.ADAS.ESC"@en .
+
+vsso:ADASLaneDepartureDetection a owl:Class ;
+    rdfs:label "ADASLaneDepartureDetection"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:ADAS ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Signals from Land Departure Detection System"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.ADAS.LaneDepartureDetection"@en .
+
+vsso:ADASObstacleDetection a owl:Class ;
+    rdfs:label "ADASObstacleDetection"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:ADAS ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Signals form Obstacle Sensor System"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.ADAS.ObstacleDetection"@en .
+
+vsso:ADASTCS a owl:Class ;
+    rdfs:label "ADASTCS"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:ADAS ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Traction Control System signals"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.ADAS.TCS"@en .
+
+vsso:Acceleration a owl:Class ;
+    rdfs:label "Acceleration"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso-core:Vehicle ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Spatial acceleration"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Acceleration"@en .
+
+vsso:AccelerationLateral a vsso-core:ObservableVehicleProperty ;
     rdfs:label "AccelerationLateral"@en ;
-    rdfs:comment "Vehicle acceleration in Y (lateral acceleration)."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Acceleration ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Acceleration.Lateral"@en .
+    skos:definition "Vehicle acceleration in Y (lateral acceleration)."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Acceleration.Lateral"@en .
 
-vsso:AccelerationLongitudinal a owl:Class ;
+vsso:AccelerationLongitudinal a vsso-core:ObservableVehicleProperty ;
     rdfs:label "AccelerationLongitudinal"@en ;
-    rdfs:comment "Vehicle acceleration in X (longitudinal acceleration)."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Acceleration ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Acceleration.Longitudinal"@en .
+    skos:definition "Vehicle acceleration in X (longitudinal acceleration)."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Acceleration.Longitudinal"@en .
 
-vsso:AccelerationVertical a owl:Class ;
+vsso:AccelerationVertical a vsso-core:ObservableVehicleProperty ;
     rdfs:label "AccelerationVertical"@en ;
-    rdfs:comment "Vehicle acceleration in Z (vertical acceleration)."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Acceleration ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Acceleration.Vertical"@en .
+    skos:definition "Vehicle acceleration in Z (vertical acceleration)."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Acceleration.Vertical"@en .
 
-vsso:AcceleratorPedalPosition a owl:Class ;
+vsso:AcceleratorPedalPosition a vsso-core:ObservableVehicleProperty ;
     rdfs:label "AcceleratorPedalPosition"@en ;
-    rdfs:comment "Accelerator pedal position as percent. 0 = Not depressed. 100 = Fully depressed."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ChassisAccelerator ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Chassis.Accelerator.PedalPosition"@en .
+    skos:definition "Accelerator pedal position as percent. 0 = Not depressed. 100 = Fully depressed."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.Accelerator.PedalPosition"@en .
 
-vsso:AirbagIsDeployed a owl:Class ;
+vsso:AirbagIsDeployed a vsso-core:ObservableVehicleProperty ;
     rdfs:label "AirbagIsDeployed"@en ;
-    rdfs:comment "Airbag deployment status. True = Airbag deployed. False = Airbag not deployed."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SeatAirbag ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.Airbag.IsDeployed"@en .
+    skos:definition "Airbag deployment status. True = Airbag deployed. False = Airbag not deployed."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Airbag.IsDeployed"@en .
 
-vsso:AmbientAirTemperature a owl:Class ;
+vsso:AmbientAirTemperature a vsso-core:ObservableVehicleProperty ;
     rdfs:label "AmbientAirTemperature"@en ;
-    rdfs:comment "Ambient air temperature outside the vehicle."@en ;
+    skos:definition "Ambient air temperature outside the vehicle."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.AmbientAirTemperature"@en .
+
+vsso:AngularVelocity a owl:Class ;
+    rdfs:label "AngularVelocity"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.AmbientAirTemperature"@en .
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Spatial rotation"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.AngularVelocity"@en .
 
-vsso:AngularVelocityPitch a owl:Class ;
+vsso:AngularVelocityPitch a vsso-core:ObservableVehicleProperty ;
     rdfs:label "AngularVelocityPitch"@en ;
-    rdfs:comment "Vehicle rotation rate along Y (lateral)."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:AngularVelocity ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.AngularVelocity.Pitch"@en .
+    skos:definition "Vehicle rotation rate along Y (lateral)."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.AngularVelocity.Pitch"@en .
 
-vsso:AngularVelocityRoll a owl:Class ;
+vsso:AngularVelocityRoll a vsso-core:ObservableVehicleProperty ;
     rdfs:label "AngularVelocityRoll"@en ;
-    rdfs:comment "Vehicle rotation rate along X (longitudinal)."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:AngularVelocity ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.AngularVelocity.Roll"@en .
+    skos:definition "Vehicle rotation rate along X (longitudinal)."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.AngularVelocity.Roll"@en .
 
-vsso:AngularVelocityYaw a owl:Class ;
+vsso:AngularVelocityYaw a vsso-core:ObservableVehicleProperty ;
     rdfs:label "AngularVelocityYaw"@en ;
-    rdfs:comment "Vehicle rotation rate along Z (vertical)."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:AngularVelocity ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.AngularVelocity.Yaw"@en .
+    skos:definition "Vehicle rotation rate along Z (vertical)."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.AngularVelocity.Yaw"@en .
 
-vsso:AverageSpeed a owl:Class ;
+vsso:AverageSpeed a vsso-core:ObservableVehicleProperty ;
     rdfs:label "AverageSpeed"@en ;
-    rdfs:comment "Average speed for the current trip"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.AverageSpeed"@en .
+    skos:definition "Average speed for the current trip"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.AverageSpeed"@en .
 
 vsso:AxleTireAspectRatio a owl:Class ;
     rdfs:label "AxleTireAspectRatio"@en ;
-    rdfs:comment "Aspect ratio between tire section height and tire section width, as per ETRTO / TRA standard."@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:ChassisAxle ;
             owl:onProperty vsso-core:belongsToVehicleComponent ],
         vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Chassis.Axle.TireAspectRatio"@en .
+    skos:definition "Aspect ratio between tire section height and tire section width, as per ETRTO / TRA standard."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle.TireAspectRatio"@en .
 
 vsso:AxleTireDiameter a owl:Class ;
     rdfs:label "AxleTireDiameter"@en ;
-    rdfs:comment "Outer diameter of tires, in inches, as per ETRTO / TRA standard."@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:ChassisAxle ;
             owl:onProperty vsso-core:belongsToVehicleComponent ],
         vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Chassis.Axle.TireDiameter"@en .
+    skos:definition "Outer diameter of tires, in inches, as per ETRTO / TRA standard."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle.TireDiameter"@en .
 
 vsso:AxleTireWidth a owl:Class ;
     rdfs:label "AxleTireWidth"@en ;
-    rdfs:comment "Nominal section width of tires, in mm, as per ETRTO / TRA standard."@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:ChassisAxle ;
             owl:onProperty vsso-core:belongsToVehicleComponent ],
         vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Chassis.Axle.TireWidth"@en .
+    skos:definition "Nominal section width of tires, in mm, as per ETRTO / TRA standard."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle.TireWidth"@en .
 
 vsso:AxleWheelCount a owl:Class ;
     rdfs:label "AxleWheelCount"@en ;
-    rdfs:comment "Number of wheels on the axle"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:ChassisAxle ;
             owl:onProperty vsso-core:belongsToVehicleComponent ],
         vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Chassis.Axle.WheelCount"@en .
+    skos:definition "Number of wheels on the axle"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle.WheelCount"@en .
 
 vsso:AxleWheelDiameter a owl:Class ;
     rdfs:label "AxleWheelDiameter"@en ;
-    rdfs:comment "Diameter of wheels (rims without tires), in inches, as per ETRTO / TRA standard."@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:ChassisAxle ;
             owl:onProperty vsso-core:belongsToVehicleComponent ],
         vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Chassis.Axle.WheelDiameter"@en .
+    skos:definition "Diameter of wheels (rims without tires), in inches, as per ETRTO / TRA standard."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle.WheelDiameter"@en .
 
 vsso:AxleWheelWidth a owl:Class ;
     rdfs:label "AxleWheelWidth"@en ;
-    rdfs:comment "Width of wheels (rims without tires), in inches, as per ETRTO / TRA standard."@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:ChassisAxle ;
             owl:onProperty vsso-core:belongsToVehicleComponent ],
         vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Chassis.Axle.WheelWidth"@en .
+    skos:definition "Width of wheels (rims without tires), in inches, as per ETRTO / TRA standard."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle.WheelWidth"@en .
 
-vsso:Bank1Temperature1 a owl:Class ;
+vsso:Bank1Temperature1 a vsso-core:ObservableVehicleProperty ;
     rdfs:label "Bank1Temperature1"@en ;
-    rdfs:comment "PID 3C - Catalyst temperature from bank 1, sensor 1"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CatalystBank1 ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.Catalyst.Bank1.Temperature1"@en .
+    skos:definition "PID 3C - Catalyst temperature from bank 1, sensor 1"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.Catalyst.Bank1.Temperature1"@en .
 
-vsso:Bank1Temperature2 a owl:Class ;
+vsso:Bank1Temperature2 a vsso-core:ObservableVehicleProperty ;
     rdfs:label "Bank1Temperature2"@en ;
-    rdfs:comment "PID 3E - Catalyst temperature from bank 1, sensor 2"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CatalystBank1 ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.Catalyst.Bank1.Temperature2"@en .
+    skos:definition "PID 3E - Catalyst temperature from bank 1, sensor 2"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.Catalyst.Bank1.Temperature2"@en .
 
-vsso:Bank2Temperature1 a owl:Class ;
+vsso:Bank2Temperature1 a vsso-core:ObservableVehicleProperty ;
     rdfs:label "Bank2Temperature1"@en ;
-    rdfs:comment "PID 3D - Catalyst temperature from bank 2, sensor 1"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CatalystBank2 ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.Catalyst.Bank2.Temperature1"@en .
+    skos:definition "PID 3D - Catalyst temperature from bank 2, sensor 1"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.Catalyst.Bank2.Temperature1"@en .
 
-vsso:Bank2Temperature2 a owl:Class ;
+vsso:Bank2Temperature2 a vsso-core:ObservableVehicleProperty ;
     rdfs:label "Bank2Temperature2"@en ;
-    rdfs:comment "PID 3F - Catalyst temperature from bank 2, sensor 2"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CatalystBank2 ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.Catalyst.Bank2.Temperature2"@en .
+    skos:definition "PID 3F - Catalyst temperature from bank 2, sensor 2"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.Catalyst.Bank2.Temperature2"@en .
 
-vsso:BatteryAccumulatedChargedEnergy a owl:Class ;
+vsso:BatteryAccumulatedChargedEnergy a vsso-core:ObservableVehicleProperty ;
     rdfs:label "BatteryAccumulatedChargedEnergy"@en ;
-    rdfs:comment "The accumulated energy delivered to the battery during charging over lifetime."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainBattery ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Battery.AccumulatedChargedEnergy"@en .
+    skos:definition "The accumulated energy delivered to the battery during charging over lifetime."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.AccumulatedChargedEnergy"@en .
 
-vsso:BatteryAccumulatedConsumedEnergy a owl:Class ;
+vsso:BatteryAccumulatedConsumedEnergy a vsso-core:ObservableVehicleProperty ;
     rdfs:label "BatteryAccumulatedConsumedEnergy"@en ;
-    rdfs:comment "The accumulated energy leaving HV battery for propulsion and auxiliary loads over lifetime."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainBattery ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Battery.AccumulatedConsumedEnergy"@en .
+    skos:definition "The accumulated energy leaving HV battery for propulsion and auxiliary loads over lifetime."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.AccumulatedConsumedEnergy"@en .
 
 vsso:BatteryGrossCapacity a owl:Class ;
     rdfs:label "BatteryGrossCapacity"@en ;
-    rdfs:comment "Gross capacity of the battery"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:PowertrainBattery ;
             owl:onProperty vsso-core:belongsToVehicleComponent ],
         vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Battery.GrossCapacity"@en .
+    skos:definition "Gross capacity of the battery"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.GrossCapacity"@en .
 
-vsso:BatteryGroundConnected a owl:Class ;
+vsso:BatteryGroundConnected a vsso-core:ObservableVehicleProperty ;
     rdfs:label "BatteryGroundConnected"@en ;
-    rdfs:comment "Indicating if the ground (negative terminator) of the traction battery is connected to the powertrain."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainBattery ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Battery.GroundConnected"@en .
+    skos:definition "Indicating if the ground (negative terminator) of the traction battery is connected to the powertrain."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.GroundConnected"@en .
 
 vsso:BatteryNetCapacity a owl:Class ;
     rdfs:label "BatteryNetCapacity"@en ;
-    rdfs:comment "Net capacity of the battery"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:PowertrainBattery ;
             owl:onProperty vsso-core:belongsToVehicleComponent ],
         vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Battery.NetCapacity"@en .
+    skos:definition "Net capacity of the battery"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.NetCapacity"@en .
 
 vsso:BatteryNominalVoltage a owl:Class ;
     rdfs:label "BatteryNominalVoltage"@en ;
-    rdfs:comment "Nominal Voltage of the battery"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:PowertrainBattery ;
             owl:onProperty vsso-core:belongsToVehicleComponent ],
         vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Battery.NominalVoltage"@en .
+    skos:definition "Nominal Voltage of the battery"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.NominalVoltage"@en .
 
-vsso:BatteryPowerConnected a owl:Class ;
+vsso:BatteryPowerConnected a vsso-core:ObservableVehicleProperty ;
     rdfs:label "BatteryPowerConnected"@en ;
-    rdfs:comment "Indicating if the power (positive terminator) of the traction battery is connected to the powertrain."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainBattery ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Battery.PowerConnected"@en .
+    skos:definition "Indicating if the power (positive terminator) of the traction battery is connected to the powertrain."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.PowerConnected"@en .
 
-vsso:BatteryRange a owl:Class ;
+vsso:BatteryRange a vsso-core:ObservableVehicleProperty ;
     rdfs:label "BatteryRange"@en ;
-    rdfs:comment "Remaining range in meters using only battery."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainBattery ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Battery.Range"@en .
+    skos:definition "Remaining range in meters using only battery."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Range"@en .
 
 vsso:BatteryReferentVoltage a owl:Class ;
     rdfs:label "BatteryReferentVoltage"@en ;
-    rdfs:comment "Referent Voltage of the battery"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:PowertrainBattery ;
             owl:onProperty vsso-core:belongsToVehicleComponent ],
         vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Battery.ReferentVoltage"@en .
+    skos:definition "Referent Voltage of the battery"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.ReferentVoltage"@en .
 
-vsso:BatteryTemperature a owl:Class ;
-    rdfs:label "BatteryTemperature"@en ;
-    rdfs:comment "Temperature of the battery pack"@en ;
+vsso:BatteryStateOfCharge a owl:Class ;
+    rdfs:label "BatteryStateOfCharge"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:PowertrainBattery ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Battery.Temperature"@en .
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Information on the state of charge of the vehicle's high voltage battery."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.StateOfCharge"@en .
+
+vsso:BatteryTemperature a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "BatteryTemperature"@en ;
+    skos:definition "Temperature of the battery pack"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Temperature"@en .
 
 vsso:BodyBodyType a owl:Class ;
     rdfs:label "BodyBodyType"@en ;
-    rdfs:comment "Body type code as defined by ISO 3779"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:Body ;
             owl:onProperty vsso-core:belongsToVehicleComponent ],
         vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Body.BodyType"@en .
+    skos:definition "Body type code as defined by ISO 3779"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.BodyType"@en .
+
+vsso:BodyHood a owl:Class ;
+    rdfs:label "BodyHood"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:Body ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Hood status"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Hood"@en .
+
+vsso:BodyHorn a owl:Class ;
+    rdfs:label "BodyHorn"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:Body ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Horn signals"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Horn"@en .
+
+vsso:BodyLights a owl:Class ;
+    rdfs:label "BodyLights"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:Body ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "All lights"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Lights"@en .
+
+vsso:BodyRaindetection a owl:Class ;
+    rdfs:label "BodyRaindetection"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:Body ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Rainsensor signals"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Raindetection"@en .
 
 vsso:BodyRefuelPosition a owl:Class ;
     rdfs:label "BodyRefuelPosition"@en ;
-    rdfs:comment "Location of the fuel cap or charge port"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:Body ;
             owl:onProperty vsso-core:belongsToVehicleComponent ],
         vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Body.RefuelPosition"@en .
+    skos:definition "Location of the fuel cap or charge port"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.RefuelPosition"@en .
 
-vsso:BrakeBrakesWorn a owl:Class ;
+vsso:BodyTrunk a owl:Class ;
+    rdfs:label "BodyTrunk"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:Body ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Trunk status"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Trunk"@en .
+
+vsso:BrakeBrakesWorn a vsso-core:ObservableVehicleProperty ;
     rdfs:label "BrakeBrakesWorn"@en ;
-    rdfs:comment "Brake pad wear status. True = Worn. False = Not Worn."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:WheelBrake ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Chassis.Axle.Wheel.Brake.BrakesWorn"@en .
+    skos:definition "Brake pad wear status. True = Worn. False = Not Worn."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle.Wheel.Brake.BrakesWorn"@en .
 
-vsso:BrakeFluidLevel a owl:Class ;
+vsso:BrakeFluidLevel a vsso-core:ObservableVehicleProperty ;
     rdfs:label "BrakeFluidLevel"@en ;
-    rdfs:comment "Brake fluid level as percent. 0 = Empty. 100 = Full."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:WheelBrake ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Chassis.Axle.Wheel.Brake.FluidLevel"@en .
+    skos:definition "Brake fluid level as percent. 0 = Empty. 100 = Full."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle.Wheel.Brake.FluidLevel"@en .
 
-vsso:BrakeFluidLevelLow a owl:Class ;
+vsso:BrakeFluidLevelLow a vsso-core:ObservableVehicleProperty ;
     rdfs:label "BrakeFluidLevelLow"@en ;
-    rdfs:comment "Brake fluid level status. True = Brake fluid level low. False = Brake fluid level OK."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:WheelBrake ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Chassis.Axle.Wheel.Brake.FluidLevelLow"@en .
+    skos:definition "Brake fluid level status. True = Brake fluid level low. False = Brake fluid level OK."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle.Wheel.Brake.FluidLevelLow"@en .
 
-vsso:BrakePadWear a owl:Class ;
+vsso:BrakePadWear a vsso-core:ObservableVehicleProperty ;
     rdfs:label "BrakePadWear"@en ;
-    rdfs:comment "Brake pad wear as percent. 0 = No Wear. 100 = Worn."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:WheelBrake ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Chassis.Axle.Wheel.Brake.PadWear"@en .
+    skos:definition "Brake pad wear as percent. 0 = No Wear. 100 = Worn."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle.Wheel.Brake.PadWear"@en .
 
-vsso:BrakePedalPosition a owl:Class ;
+vsso:BrakePedalPosition a vsso-core:ObservableVehicleProperty ;
     rdfs:label "BrakePedalPosition"@en ;
-    rdfs:comment "Brake pedal position as percent. 0 = Not depressed. 100 = Fully depressed."@en ;
+    skos:definition "Brake pedal position as percent. 0 = Not depressed. 100 = Fully depressed."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.Brake.PedalPosition"@en .
+
+vsso:CabinConvertible a owl:Class ;
+    rdfs:label "CabinConvertible"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ChassisBrake ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Chassis.Brake.PedalPosition"@en .
+            owl:allValuesFrom vsso:Cabin ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Convertible roof"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Convertible"@en .
 
 vsso:CabinDoorCount a owl:Class ;
     rdfs:label "CabinDoorCount"@en ;
-    rdfs:comment "Number of doors in vehicle"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:Cabin ;
             owl:onProperty vsso-core:belongsToVehicleComponent ],
         vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.DoorCount"@en .
+    skos:definition "Number of doors in vehicle"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.DoorCount"@en .
 
 vsso:CabinDriverPosition a owl:Class ;
     rdfs:label "CabinDriverPosition"@en ;
-    rdfs:comment "The position of the driver seat in row 1."@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:Cabin ;
             owl:onProperty vsso-core:belongsToVehicleComponent ],
         vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.DriverPosition"@en .
+    skos:definition "The position of the driver seat in row 1."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.DriverPosition"@en .
+
+vsso:CabinRearShade a owl:Class ;
+    rdfs:label "CabinRearShade"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:Cabin ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Rear window shade."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.RearShade"@en .
+
+vsso:CabinRearviewMirror a owl:Class ;
+    rdfs:label "CabinRearviewMirror"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:Cabin ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Rearview mirror"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.RearviewMirror"@en .
 
 vsso:CabinSeatPosCount a owl:Class ;
     rdfs:label "CabinSeatPosCount"@en ;
-    rdfs:comment "Number of seats across each row from the front to the rear"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:Cabin ;
             owl:onProperty vsso-core:belongsToVehicleComponent ],
         vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.SeatPosCount"@en .
+    skos:definition "Number of seats across each row from the front to the rear"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.SeatPosCount"@en .
 
 vsso:CabinSeatRowCount a owl:Class ;
     rdfs:label "CabinSeatRowCount"@en ;
-    rdfs:comment "Number of seat rows in vehicle"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:Cabin ;
             owl:onProperty vsso-core:belongsToVehicleComponent ],
         vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.SeatRowCount"@en .
+    skos:definition "Number of seat rows in vehicle"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.SeatRowCount"@en .
 
-vsso:ChargingChargeCurrent a owl:Class ;
+vsso:CatalystBank1 a owl:Class ;
+    rdfs:label "CatalystBank1"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:OBDCatalyst ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Catalyst bank 1 signals"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.Catalyst.Bank1"@en .
+
+vsso:CatalystBank2 a owl:Class ;
+    rdfs:label "CatalystBank2"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:OBDCatalyst ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Catalyst bank 2 signals"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.Catalyst.Bank2"@en .
+
+vsso:ChargingChargeCurrent a vsso-core:ObservableVehicleProperty ;
     rdfs:label "ChargingChargeCurrent"@en ;
-    rdfs:comment "Current charging current."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BatteryCharging ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Battery.Charging.ChargeCurrent"@en .
+    skos:definition "Current charging current."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Charging.ChargeCurrent"@en .
 
-vsso:ChargingChargeLimit a owl:Class ;
+vsso:ChargingChargeLimit a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
     rdfs:label "ChargingChargeLimit"@en ;
-    rdfs:comment "Maximum charge level for battery, can potentially be set manually."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BatteryCharging ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Battery.Charging.ChargeLimit"@en .
+    skos:definition "Maximum charge level for battery, can potentially be set manually."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Charging.ChargeLimit"@en .
 
-vsso:ChargingChargePlugStatus a owl:Class ;
+vsso:ChargingChargePlugStatus a vsso-core:ObservableVehicleProperty ;
     rdfs:label "ChargingChargePlugStatus"@en ;
-    rdfs:comment "Signal indicating if charge plug is connected or not."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BatteryCharging ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Battery.Charging.ChargePlugStatus"@en .
+    skos:definition "Signal indicating if charge plug is connected or not."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Charging.ChargePlugStatus"@en .
 
 vsso:ChargingChargePlugType a owl:Class ;
     rdfs:label "ChargingChargePlugType"@en ;
-    rdfs:comment "Type of charge plug available on the vehicle (CSS includes Type2)."@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:BatteryCharging ;
             owl:onProperty vsso-core:belongsToVehicleComponent ],
         vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Battery.Charging.ChargePlugType"@en .
+    skos:definition "Type of charge plug available on the vehicle (CSS includes Type2)."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Charging.ChargePlugType"@en .
 
-vsso:ChargingChargePortFlap a owl:Class ;
+vsso:ChargingChargePortFlap a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
     rdfs:label "ChargingChargePortFlap"@en ;
-    rdfs:comment "Signal indicating if charge port cover is open or closed, can potentially be controlled manually."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BatteryCharging ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Battery.Charging.ChargePortFlap"@en .
+    skos:definition "Signal indicating if charge port cover is open or closed, can potentially be controlled manually."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Charging.ChargePortFlap"@en .
 
-vsso:ChargingChargeRate a owl:Class ;
+vsso:ChargingChargeRate a vsso-core:ObservableVehicleProperty ;
     rdfs:label "ChargingChargeRate"@en ;
-    rdfs:comment "Current charging rate, as in kilometers of range added per hour."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BatteryCharging ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Battery.Charging.ChargeRate"@en .
+    skos:definition "Current charging rate, as in kilometers of range added per hour."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Charging.ChargeRate"@en .
 
-vsso:ChargingChargeVoltage a owl:Class ;
+vsso:ChargingChargeVoltage a vsso-core:ObservableVehicleProperty ;
     rdfs:label "ChargingChargeVoltage"@en ;
-    rdfs:comment "Current charging voltage."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BatteryCharging ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Battery.Charging.ChargeVoltage"@en .
+    skos:definition "Current charging voltage."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Charging.ChargeVoltage"@en .
 
-vsso:ChargingMaximumChargingCurrent a owl:Class ;
+vsso:ChargingMaximumChargingCurrent a vsso-core:ObservableVehicleProperty ;
     rdfs:label "ChargingMaximumChargingCurrent"@en ;
-    rdfs:comment "Maximum charging current that can be accepted by the system."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BatteryCharging ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Battery.Charging.MaximumChargingCurrent"@en .
+    skos:definition "Maximum charging current that can be accepted by the system."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Charging.MaximumChargingCurrent"@en .
 
-vsso:ChargingMode a owl:Class ;
-    rdfs:label "ChargingMode"@en ;
-    rdfs:comment "Control of the charge process - manually initiated (plug-in event, companion app, etc), timer-based or grid-controlled (eg ISO 15118)."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BatteryCharging ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
+vsso:ChargingMode a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Battery.Charging.Mode"@en .
+    rdfs:label "ChargingMode"@en ;
+    skos:definition "Control of the charge process - manually initiated (plug-in event, companion app, etc), timer-based or grid-controlled (eg ISO 15118)."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Charging.Mode"@en .
 
 vsso:ChargingPortType a owl:Class ;
     rdfs:label "ChargingPortType"@en ;
-    rdfs:comment "Indicates the primary charging type fitted to the vehicle"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:BodyChargingPort ;
             owl:onProperty vsso-core:belongsToVehicleComponent ],
         vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Body.ChargingPort.Type"@en .
+    skos:definition "Indicates the primary charging type fitted to the vehicle"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.ChargingPort.Type"@en .
 
-vsso:ChargingStartStopCharging a owl:Class ;
+vsso:ChargingStartStopCharging a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
     rdfs:label "ChargingStartStopCharging"@en ;
-    rdfs:comment "Start or stop the charging process."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BatteryCharging ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Battery.Charging.StartStopCharging"@en .
+    skos:definition "Start or stop the charging process."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Charging.StartStopCharging"@en .
 
-vsso:ChargingStatus a owl:Class ;
+vsso:ChargingStatus a vsso-core:ObservableVehicleProperty ;
     rdfs:label "ChargingStatus"@en ;
-    rdfs:comment "State of charging process."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BatteryCharging ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Battery.Charging.Status"@en .
+    skos:definition "State of charging process."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Charging.Status"@en .
 
-vsso:ChargingTimeToComplete a owl:Class ;
+vsso:ChargingTimeToComplete a vsso-core:ObservableVehicleProperty ;
     rdfs:label "ChargingTimeToComplete"@en ;
-    rdfs:comment "The time needed to complete the current charging process to the set charge limit. 0 if charging is complete, negative number if no charging process is active."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BatteryCharging ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Battery.Charging.TimeToComplete"@en .
-
-vsso:ChassisAxleCount a owl:Class ;
-    rdfs:label "ChassisAxleCount"@en ;
-    rdfs:comment "Number of axles on the vehicle"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Chassis ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Chassis.AxleCount"@en .
-
-vsso:ChassisCurbWeight a owl:Class ;
-    rdfs:label "ChassisCurbWeight"@en ;
-    rdfs:comment "Vehicle curb weight, in kg, including all liquids and full tank of fuel, but no cargo or passengers."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Chassis ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Chassis.CurbWeight"@en .
-
-vsso:ChassisGrossWeight a owl:Class ;
-    rdfs:label "ChassisGrossWeight"@en ;
-    rdfs:comment "Curb weight of vehicle, including all liquids and full tank of fuel and full load of cargo and passengers."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Chassis ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Chassis.GrossWeight"@en .
-
-vsso:ChassisHeight a owl:Class ;
-    rdfs:label "ChassisHeight"@en ;
-    rdfs:comment "Overall vehicle height, in mm."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Chassis ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Chassis.Height"@en .
-
-vsso:ChassisLength a owl:Class ;
-    rdfs:label "ChassisLength"@en ;
-    rdfs:comment "Overall vehicle length, in mm."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Chassis ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Chassis.Length"@en .
-
-vsso:ChassisTowWeight a owl:Class ;
-    rdfs:label "ChassisTowWeight"@en ;
-    rdfs:comment "Maximum weight, in kilos, of trailer."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Chassis ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Chassis.TowWeight"@en .
-
-vsso:ChassisTrack a owl:Class ;
-    rdfs:label "ChassisTrack"@en ;
-    rdfs:comment "Overall wheel tracking, in mm."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Chassis ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Chassis.Track"@en .
-
-vsso:ChassisTrailerConnected a owl:Class ;
-    rdfs:label "ChassisTrailerConnected"@en ;
-    rdfs:comment "Signal indicating if trailer is connected or not."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ChassisTrailer ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Chassis.Trailer.Connected"@en .
-
-vsso:ChassisWheelbase a owl:Class ;
-    rdfs:label "ChassisWheelbase"@en ;
-    rdfs:comment "Overall wheel base, in mm."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Chassis ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Chassis.Wheelbase"@en .
-
-vsso:ChassisWidth a owl:Class ;
-    rdfs:label "ChassisWidth"@en ;
-    rdfs:comment "Overall vehicle width, in mm."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Chassis ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Chassis.Width"@en .
-
-vsso:CombustionEngineAspirationType a owl:Class ;
-    rdfs:label "CombustionEngineAspirationType"@en ;
-    rdfs:comment "Type of aspiration (natural, turbocharger, supercharger etc)."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.CombustionEngine.AspirationType"@en .
-
-vsso:CombustionEngineBore a owl:Class ;
-    rdfs:label "CombustionEngineBore"@en ;
-    rdfs:comment "Bore in millimetres."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.CombustionEngine.Bore"@en .
-
-vsso:CombustionEngineCompressionRatio a owl:Class ;
-    rdfs:label "CombustionEngineCompressionRatio"@en ;
-    rdfs:comment "Engine compression ratio."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.CombustionEngine.CompressionRatio"@en .
-
-vsso:CombustionEngineConfiguration a owl:Class ;
-    rdfs:label "CombustionEngineConfiguration"@en ;
-    rdfs:comment "Engine configuration."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.CombustionEngine.Configuration"@en .
-
-vsso:CombustionEngineDisplacement a owl:Class ;
-    rdfs:label "CombustionEngineDisplacement"@en ;
-    rdfs:comment "Displacement in cubic centimetres."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.CombustionEngine.Displacement"@en .
-
-vsso:CombustionEngineEngineCoolantCapacity a owl:Class ;
-    rdfs:label "CombustionEngineEngineCoolantCapacity"@en ;
-    rdfs:comment "Engine coolant capacity in liters."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.CombustionEngine.EngineCoolantCapacity"@en .
-
-vsso:CombustionEngineEngineOilCapacity a owl:Class ;
-    rdfs:label "CombustionEngineEngineOilCapacity"@en ;
-    rdfs:comment "Engine oil capacity in liters."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.CombustionEngine.EngineOilCapacity"@en .
-
-vsso:CombustionEngineEngineOilLevel a owl:Class ;
-    rdfs:label "CombustionEngineEngineOilLevel"@en ;
-    rdfs:comment "Vehicle oil level."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.CombustionEngine.EngineOilLevel"@en .
-
-vsso:CombustionEngineFuelType a owl:Class ;
-    rdfs:label "CombustionEngineFuelType"@en ;
-    rdfs:comment "Type of fuel that the engine runs on."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.CombustionEngine.FuelType"@en .
-
-vsso:CombustionEngineMaxPower a owl:Class ;
-    rdfs:label "CombustionEngineMaxPower"@en ;
-    rdfs:comment "Peak power, in kilowatts, that engine can generate."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.CombustionEngine.MaxPower"@en .
-
-vsso:CombustionEngineMaxTorque a owl:Class ;
-    rdfs:label "CombustionEngineMaxTorque"@en ;
-    rdfs:comment "Peak power, in newton meter, that the engine can generate."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.CombustionEngine.MaxTorque"@en .
-
-vsso:CombustionEngineNumberOfCylinders a owl:Class ;
-    rdfs:label "CombustionEngineNumberOfCylinders"@en ;
-    rdfs:comment "Number of cylinders."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.CombustionEngine.NumberOfCylinders"@en .
-
-vsso:CombustionEngineNumberOfValvesPerCylinder a owl:Class ;
-    rdfs:label "CombustionEngineNumberOfValvesPerCylinder"@en ;
-    rdfs:comment "Number of valves per cylinder."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.CombustionEngine.NumberOfValvesPerCylinder"@en .
-
-vsso:CombustionEngineOilLifeRemaining a owl:Class ;
-    rdfs:label "CombustionEngineOilLifeRemaining"@en ;
-    rdfs:comment "Remaining engine oil life in seconds. Negative values can be used to indicate that lifetime has been exceeded."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.CombustionEngine.OilLifeRemaining"@en .
-
-vsso:CombustionEngineStrokeLength a owl:Class ;
-    rdfs:label "CombustionEngineStrokeLength"@en ;
-    rdfs:comment "Stroke length in millimetres."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.CombustionEngine.StrokeLength"@en .
-
-vsso:ConvertibleStatus a owl:Class ;
-    rdfs:label "ConvertibleStatus"@en ;
-    rdfs:comment "Roof status on convertible vehicles"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinConvertible ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Convertible.Status"@en .
-
-vsso:CruiseControlError a owl:Class ;
-    rdfs:label "CruiseControlError"@en ;
-    rdfs:comment "Indicates if cruise control system incurred and error condition. True = Error. False = NoError."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ADASCruiseControl ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.ADAS.CruiseControl.Error"@en .
-
-vsso:CruiseControlIsActive a owl:Class ;
-    rdfs:label "CruiseControlIsActive"@en ;
-    rdfs:comment "Indicates if cruise control system is enabled. True = Enabled. False = Disabled."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ADASCruiseControl ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.ADAS.CruiseControl.IsActive"@en .
-
-vsso:CruiseControlSpeedSet a owl:Class ;
-    rdfs:label "CruiseControlSpeedSet"@en ;
-    rdfs:comment "Set cruise control speed in kilometers per hour"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ADASCruiseControl ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.ADAS.CruiseControl.SpeedSet"@en .
-
-vsso:CurbWeight a owl:Class ;
-    rdfs:label "CurbWeight"@en ;
-    rdfs:comment "Vehicle curb weight, including all liquids and full tank of fuel, but no cargo or passengers."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.CurbWeight"@en .
-
-vsso:CurrentLocationAccuracy a owl:Class ;
-    rdfs:label "CurrentLocationAccuracy"@en ;
-    rdfs:comment "Accuracy level of the latitude and longitude coordinates."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CurrentLocation ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.CurrentLocation.Accuracy"@en .
-
-vsso:CurrentLocationAltitude a owl:Class ;
-    rdfs:label "CurrentLocationAltitude"@en ;
-    rdfs:comment "Current elevation of the position."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CurrentLocation ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.CurrentLocation.Altitude"@en .
-
-vsso:CurrentLocationHeading a owl:Class ;
-    rdfs:label "CurrentLocationHeading"@en ;
-    rdfs:comment "Current magnetic compass heading."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CurrentLocation ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.CurrentLocation.Heading"@en .
-
-vsso:CurrentLocationLatitude a owl:Class ;
-    rdfs:label "CurrentLocationLatitude"@en ;
-    rdfs:comment "Current latitude of vehicle."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CurrentLocation ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.CurrentLocation.Latitude"@en .
-
-vsso:CurrentLocationLongitude a owl:Class ;
-    rdfs:label "CurrentLocationLongitude"@en ;
-    rdfs:comment "Current longitude of vehicle."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CurrentLocation ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.CurrentLocation.Longitude"@en .
-
-vsso:CurrentLocationSpeed a owl:Class ;
-    rdfs:label "CurrentLocationSpeed"@en ;
-    rdfs:comment "Vehicle speed, as sensed by the GPS receiver."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:NavigationCurrentLocation ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Infotainment.Navigation.CurrentLocation.Speed"@en .
-
-vsso:CurrentOverallWeight a owl:Class ;
-    rdfs:label "CurrentOverallWeight"@en ;
-    rdfs:comment "Current overall Vehicle weight. Including passengers, cargo and other load inside the car."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.CurrentOverallWeight"@en .
-
-vsso:CushionBackward a owl:Class ;
-    rdfs:label "CushionBackward"@en ;
-    rdfs:comment "Seat cushion backward/shorten switch engaged (SingleSeat.Cushion.Length)"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SwitchCushion ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.Switch.Cushion.Backward"@en .
-
-vsso:CushionDown a owl:Class ;
-    rdfs:label "CushionDown"@en ;
-    rdfs:comment "Seat cushion down switch engaged (SingleSeat.Cushion.Height)"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SwitchCushion ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.Switch.Cushion.Down"@en .
-
-vsso:CushionForward a owl:Class ;
-    rdfs:label "CushionForward"@en ;
-    rdfs:comment "Seat cushion forward/lengthen switch engaged (SingleSeat.Cushion.Length)"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SwitchCushion ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.Switch.Cushion.Forward"@en .
-
-vsso:CushionHeight a owl:Class ;
-    rdfs:label "CushionHeight"@en ;
-    rdfs:comment "Height of the seat cushion (leg support), relative to seat. 0 = Lowermost. 500 = Uppermost."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SeatCushion ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.Cushion.Height"@en .
-
-vsso:CushionLength a owl:Class ;
-    rdfs:label "CushionLength"@en ;
-    rdfs:comment "Forward length of cushion (leg support), relative to seat. 0 = Rearmost. 500 = Forwardmost."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SeatCushion ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.Cushion.Length"@en .
-
-vsso:CushionUp a owl:Class ;
-    rdfs:label "CushionUp"@en ;
-    rdfs:comment "Seat cushion up switch engaged (SingleSeat.Cushion.Height)"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SwitchCushion ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.Switch.Cushion.Up"@en .
-
-vsso:DestinationSetLatitude a owl:Class ;
-    rdfs:label "DestinationSetLatitude"@en ;
-    rdfs:comment "Latitude of destination"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:NavigationDestinationSet ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Infotainment.Navigation.DestinationSet.Latitude"@en .
-
-vsso:DestinationSetLongitude a owl:Class ;
-    rdfs:label "DestinationSetLongitude"@en ;
-    rdfs:comment "Longitude of destination"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:NavigationDestinationSet ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Infotainment.Navigation.DestinationSet.Longitude"@en .
-
-vsso:DieselParticulateFilterDeltaPressure a owl:Class ;
-    rdfs:label "DieselParticulateFilterDeltaPressure"@en ;
-    rdfs:comment "Delta Pressure of Diesel Particulate Filter."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CombustionEngineDieselParticulateFilter ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.CombustionEngine.DieselParticulateFilter.DeltaPressure"@en .
-
-vsso:DieselParticulateFilterInletTemperature a owl:Class ;
-    rdfs:label "DieselParticulateFilterInletTemperature"@en ;
-    rdfs:comment "Inlet temperature of Diesel Particulate Filter."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CombustionEngineDieselParticulateFilter ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.CombustionEngine.DieselParticulateFilter.InletTemperature"@en .
-
-vsso:DieselParticulateFilterOutletTemperature a owl:Class ;
-    rdfs:label "DieselParticulateFilterOutletTemperature"@en ;
-    rdfs:comment "Outlet temperature of Diesel Particulate Filter."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CombustionEngineDieselParticulateFilter ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.CombustionEngine.DieselParticulateFilter.OutletTemperature"@en .
-
-vsso:DoorIsChildLockActive a owl:Class ;
-    rdfs:label "DoorIsChildLockActive"@en ;
-    rdfs:comment "Is door child lock engaged. True = Engaged. False = Disengaged."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinDoor ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Door.IsChildLockActive"@en .
-
-vsso:DoorIsLocked a owl:Class ;
-    rdfs:label "DoorIsLocked"@en ;
-    rdfs:comment "Is door locked or unlocked. True = Locked. False = Unlocked."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinDoor ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Door.IsLocked"@en .
-
-vsso:DoorIsOpen a owl:Class ;
-    rdfs:label "DoorIsOpen"@en ;
-    rdfs:comment "Is door open or closed"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinDoor ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Door.IsOpen"@en .
-
-vsso:DoorShadePosition a owl:Class ;
-    rdfs:label "DoorShadePosition"@en ;
-    rdfs:comment "Position of window blind. 0 = Fully retracted. 100 = Fully deployed."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:DoorShade ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Door.Shade.Position"@en .
-
-vsso:DoorShadeSwitch a owl:Class ;
-    rdfs:label "DoorShadeSwitch"@en ;
-    rdfs:comment "Switch controlling sliding action such as window, sunroof, or blind."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:DoorShade ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Door.Shade.Switch"@en .
-
-vsso:DriveCycleStatusDTCCount a owl:Class ;
-    rdfs:label "DriveCycleStatusDTCCount"@en ;
-    rdfs:comment "Number of sensor Trouble Codes (DTC)"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBDDriveCycleStatus ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.DriveCycleStatus.DTCCount"@en .
-
-vsso:DriveCycleStatusIgnitionType a owl:Class ;
-    rdfs:label "DriveCycleStatusIgnitionType"@en ;
-    rdfs:comment "Type of the ignition for ICE - spark = spark plug ignition, compression = self-igniting (Diesel engines)"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBDDriveCycleStatus ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.DriveCycleStatus.IgnitionType"@en .
-
-vsso:DriveCycleStatusMIL a owl:Class ;
-    rdfs:label "DriveCycleStatusMIL"@en ;
-    rdfs:comment "Malfunction Indicator Light (MIL) - False = Off, True = On"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBDDriveCycleStatus ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.DriveCycleStatus.MIL"@en .
-
-vsso:DriveTime a owl:Class ;
-    rdfs:label "DriveTime"@en ;
-    rdfs:comment "Accumulated drive time in seconds."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.DriveTime"@en .
-
-vsso:DriverAttentiveProbability a owl:Class ;
-    rdfs:label "DriverAttentiveProbability"@en ;
-    rdfs:comment "Probability of attentiveness of the driver."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Driver ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Driver.AttentiveProbability"@en .
-
-vsso:DriverDistractionLevel a owl:Class ;
-    rdfs:label "DriverDistractionLevel"@en ;
-    rdfs:comment "Distraction level of the driver will be the level how much the driver is distracted, by multiple factors. E.g. Driving situation, acustical or optical signales inside the cockpit, phone calls"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Driver ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Driver.DistractionLevel"@en .
-
-vsso:DriverEyesOnRoad a owl:Class ;
-    rdfs:label "DriverEyesOnRoad"@en ;
-    rdfs:comment "Has driver the eyes on road or not?"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Driver ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Driver.EyesOnRoad"@en .
-
-vsso:DriverFatigueLevel a owl:Class ;
-    rdfs:label "DriverFatigueLevel"@en ;
-    rdfs:comment "Fatigueness level of driver. Evaluated by multiple factors like trip time, behaviour of steering, eye status."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Driver ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Driver.FatigueLevel"@en .
-
-vsso:DriverHeartRate a owl:Class ;
-    rdfs:label "DriverHeartRate"@en ;
-    rdfs:comment "Heart rate of the driver."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Driver ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Driver.HeartRate"@en .
-
-vsso:DriverIdentifierIssuer a owl:Class ;
-    rdfs:label "DriverIdentifierIssuer"@en ;
-    rdfs:comment "Unique Issuer for the authentification of the occupant. E.g. https://accounts.funcorp.com"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:DriverIdentifier ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Driver.Identifier.Issuer"@en .
-
-vsso:DriverIdentifierSubject a owl:Class ;
-    rdfs:label "DriverIdentifierSubject"@en ;
-    rdfs:comment "Subject for the authentification of the occupant. E.g. UserID 7331677"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:DriverIdentifier ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Driver.Identifier.Subject"@en .
-
-vsso:ESCError a owl:Class ;
-    rdfs:label "ESCError"@en ;
-    rdfs:comment "Indicates if ESC incurred an error condition. True = Error. False = No Error."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ADASESC ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.ADAS.ESC.Error"@en .
-
-vsso:ESCIsActive a owl:Class ;
-    rdfs:label "ESCIsActive"@en ;
-    rdfs:comment "Indicates if ECS is enabled. True = Enabled. False = Disabled."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ADASESC ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.ADAS.ESC.IsActive"@en .
-
-vsso:ESCIsEngaged a owl:Class ;
-    rdfs:label "ESCIsEngaged"@en ;
-    rdfs:comment "Indicates if ESC is currently regulating vehicle stability. True = Engaged. False = Not Engaged."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ADASESC ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.ADAS.ESC.IsEngaged"@en .
-
-vsso:ElectricMotorMaxPower a owl:Class ;
-    rdfs:label "ElectricMotorMaxPower"@en ;
-    rdfs:comment "Peak power, in kilowatts, that motor(s) can generate."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainElectricMotor ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.ElectricMotor.MaxPower"@en .
-
-vsso:ElectricMotorMaxRegenPower a owl:Class ;
-    rdfs:label "ElectricMotorMaxRegenPower"@en ;
-    rdfs:comment "Peak regen/brake power, in kilowatts, that motor(s) can generate."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainElectricMotor ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.ElectricMotor.MaxRegenPower"@en .
-
-vsso:ElectricMotorMaxRegenTorque a owl:Class ;
-    rdfs:label "ElectricMotorMaxRegenTorque"@en ;
-    rdfs:comment "Peak regen/brake torque, in newton meter, that the motor(s) can generate."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainElectricMotor ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.ElectricMotor.MaxRegenTorque"@en .
-
-vsso:ElectricMotorMaxTorque a owl:Class ;
-    rdfs:label "ElectricMotorMaxTorque"@en ;
-    rdfs:comment "Peak power, in newton meter, that the motor(s) can generate."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainElectricMotor ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.ElectricMotor.MaxTorque"@en .
-
-vsso:EngineECT a owl:Class ;
-    rdfs:label "EngineECT"@en ;
-    rdfs:comment "Engine coolant temperature."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CombustionEngineEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.CombustionEngine.Engine.ECT"@en .
-
-vsso:EngineEOP a owl:Class ;
-    rdfs:label "EngineEOP"@en ;
-    rdfs:comment "Engine oil pressure."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CombustionEngineEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.CombustionEngine.Engine.EOP"@en .
-
-vsso:EngineEOT a owl:Class ;
-    rdfs:label "EngineEOT"@en ;
-    rdfs:comment "Engine oil temperature."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CombustionEngineEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.CombustionEngine.Engine.EOT"@en .
-
-vsso:EngineMAF a owl:Class ;
-    rdfs:label "EngineMAF"@en ;
-    rdfs:comment "Grams of air drawn into engine per second."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CombustionEngineEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.CombustionEngine.Engine.MAF"@en .
-
-vsso:EngineMAP a owl:Class ;
-    rdfs:label "EngineMAP"@en ;
-    rdfs:comment "Manifold air pressure possibly boosted using forced induction."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CombustionEngineEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.CombustionEngine.Engine.MAP"@en .
-
-vsso:EnginePower a owl:Class ;
-    rdfs:label "EnginePower"@en ;
-    rdfs:comment "Current engine power output."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CombustionEngineEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.CombustionEngine.Engine.Power"@en .
-
-vsso:EngineSpeed a owl:Class ;
-    rdfs:label "EngineSpeed"@en ;
-    rdfs:comment "Engine speed measured as rotations per minute."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CombustionEngineEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.CombustionEngine.Engine.Speed"@en .
-
-vsso:EngineTPS a owl:Class ;
-    rdfs:label "EngineTPS"@en ;
-    rdfs:comment "Current throttle position."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CombustionEngineEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.CombustionEngine.Engine.TPS"@en .
-
-vsso:EngineTorque a owl:Class ;
-    rdfs:label "EngineTorque"@en ;
-    rdfs:comment "Current engine torque."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CombustionEngineEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.CombustionEngine.Engine.Torque"@en .
-
-vsso:FuelSystemAverageConsumption a owl:Class ;
-    rdfs:label "FuelSystemAverageConsumption"@en ;
-    rdfs:comment "Average consumption in liters per 100 km."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainFuelSystem ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.FuelSystem.AverageConsumption"@en .
-
-vsso:FuelSystemConsumptionSinceStart a owl:Class ;
-    rdfs:label "FuelSystemConsumptionSinceStart"@en ;
-    rdfs:comment "Fuel amount in liters consumed since start of current trip."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainFuelSystem ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.FuelSystem.ConsumptionSinceStart"@en .
-
-vsso:FuelSystemEngineStopStartEnabled a owl:Class ;
-    rdfs:label "FuelSystemEngineStopStartEnabled"@en ;
-    rdfs:comment "Indicates whether eco start stop is currently enabled"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainFuelSystem ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.FuelSystem.EngineStopStartEnabled"@en .
-
-vsso:FuelSystemFuelType a owl:Class ;
-    rdfs:label "FuelSystemFuelType"@en ;
-    rdfs:comment "Defines the fuel type of the vehicle"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainFuelSystem ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.FuelSystem.FuelType"@en .
-
-vsso:FuelSystemHybridType a owl:Class ;
-    rdfs:label "FuelSystemHybridType"@en ;
-    rdfs:comment "Defines the hybrid type of the vehicle"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainFuelSystem ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.FuelSystem.HybridType"@en .
-
-vsso:FuelSystemInstantConsumption a owl:Class ;
-    rdfs:label "FuelSystemInstantConsumption"@en ;
-    rdfs:comment "Current consumption in liters per 100 km."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainFuelSystem ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.FuelSystem.InstantConsumption"@en .
-
-vsso:FuelSystemLevel a owl:Class ;
-    rdfs:label "FuelSystemLevel"@en ;
-    rdfs:comment "Level in fuel tank as percent of capacity. 0 = empty. 100 = full."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainFuelSystem ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.FuelSystem.Level"@en .
-
-vsso:FuelSystemLowFuelLevel a owl:Class ;
-    rdfs:label "FuelSystemLowFuelLevel"@en ;
-    rdfs:comment "Indicates that the fuel level is low (e.g. <50km range)"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainFuelSystem ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.FuelSystem.LowFuelLevel"@en .
-
-vsso:FuelSystemRange a owl:Class ;
-    rdfs:label "FuelSystemRange"@en ;
-    rdfs:comment "Remaining range in meters using only liquid fuel."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainFuelSystem ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.FuelSystem.Range"@en .
-
-vsso:FuelSystemTankCapacity a owl:Class ;
-    rdfs:label "FuelSystemTankCapacity"@en ;
-    rdfs:comment "Capacity of the fuel tank in liters"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainFuelSystem ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.FuelSystem.TankCapacity"@en .
-
-vsso:FuelSystemTimeSinceStart a owl:Class ;
-    rdfs:label "FuelSystemTimeSinceStart"@en ;
-    rdfs:comment "Time in seconds elapsed since start of current trip."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainFuelSystem ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.FuelSystem.TimeSinceStart"@en .
-
-vsso:GrossWeight a owl:Class ;
-    rdfs:label "GrossWeight"@en ;
-    rdfs:comment "Curb weight of vehicle, including all liquids and full tank of fuel and full load of cargo and passengers."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.GrossWeight"@en .
-
-vsso:HMICurrentLanguage a owl:Class ;
-    rdfs:label "HMICurrentLanguage"@en ;
-    rdfs:comment "ISO 639-1 standard language code for the current HMI"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:InfotainmentHMI ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Infotainment.HMI.CurrentLanguage"@en .
-
-vsso:HMIDateFormat a owl:Class ;
-    rdfs:label "HMIDateFormat"@en ;
-    rdfs:comment "Date format used in the current HMI"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:InfotainmentHMI ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Infotainment.HMI.DateFormat"@en .
-
-vsso:HMIDayNightMode a owl:Class ;
-    rdfs:label "HMIDayNightMode"@en ;
-    rdfs:comment "Current display theme"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:InfotainmentHMI ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Infotainment.HMI.DayNightMode"@en .
-
-vsso:HMIDistanceUnit a owl:Class ;
-    rdfs:label "HMIDistanceUnit"@en ;
-    rdfs:comment "Distance unit used in the current HMI"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:InfotainmentHMI ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Infotainment.HMI.DistanceUnit"@en .
-
-vsso:HMIEVEconomyUnits a owl:Class ;
-    rdfs:label "HMIEVEconomyUnits"@en ;
-    rdfs:comment "EV fuel economy unit used in the current HMI"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:InfotainmentHMI ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Infotainment.HMI.EVEconomyUnits"@en .
-
-vsso:HMIFuelEconomyUnits a owl:Class ;
-    rdfs:label "HMIFuelEconomyUnits"@en ;
-    rdfs:comment "Fuel economy unit used in the current HMI"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:InfotainmentHMI ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Infotainment.HMI.FuelEconomyUnits"@en .
-
-vsso:HMITemperatureUnit a owl:Class ;
-    rdfs:label "HMITemperatureUnit"@en ;
-    rdfs:comment "Temperature unit used in the current HMI"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:InfotainmentHMI ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Infotainment.HMI.TemperatureUnit"@en .
-
-vsso:HMITimeFormat a owl:Class ;
-    rdfs:label "HMITimeFormat"@en ;
-    rdfs:comment "Time format used in the current HMI"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:InfotainmentHMI ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Infotainment.HMI.TimeFormat"@en .
-
-vsso:HVACAmbientAirTemperature a owl:Class ;
-    rdfs:label "HVACAmbientAirTemperature"@en ;
-    rdfs:comment "Ambient air temperature inside the vehicle."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinHVAC ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.HVAC.AmbientAirTemperature"@en .
-
-vsso:HVACIsAirConditioningActive a owl:Class ;
-    rdfs:label "HVACIsAirConditioningActive"@en ;
-    rdfs:comment "Is Air conditioning active."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinHVAC ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.HVAC.IsAirConditioningActive"@en .
-
-vsso:HVACIsFrontDefrosterActive a owl:Class ;
-    rdfs:label "HVACIsFrontDefrosterActive"@en ;
-    rdfs:comment "Is front defroster active."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinHVAC ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.HVAC.IsFrontDefrosterActive"@en .
-
-vsso:HVACIsRearDefrosterActive a owl:Class ;
-    rdfs:label "HVACIsRearDefrosterActive"@en ;
-    rdfs:comment "Is rear defroster active."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinHVAC ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.HVAC.IsRearDefrosterActive"@en .
-
-vsso:HVACIsRecirculationActive a owl:Class ;
-    rdfs:label "HVACIsRecirculationActive"@en ;
-    rdfs:comment "Is recirculation active."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinHVAC ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.HVAC.IsRecirculationActive"@en .
-
-vsso:HeadRestraintDown a owl:Class ;
-    rdfs:label "HeadRestraintDown"@en ;
-    rdfs:comment "Head restraint down switch engaged (SingleSeat.HeadRestraint.Height)"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SwitchHeadRestraint ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.Switch.HeadRestraint.Down"@en .
-
-vsso:HeadRestraintHeight a owl:Class ;
-    rdfs:label "HeadRestraintHeight"@en ;
-    rdfs:comment "Height of head restraint. 0 = Bottommost. 255 = Uppermost."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SeatHeadRestraint ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.HeadRestraint.Height"@en .
-
-vsso:HeadRestraintUp a owl:Class ;
-    rdfs:label "HeadRestraintUp"@en ;
-    rdfs:comment "Head restraint up switch engaged (SingleSeat.HeadRestraint.Height)"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SwitchHeadRestraint ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.Switch.HeadRestraint.Up"@en .
-
-vsso:HeatingStatus a owl:Class ;
-    rdfs:label "HeatingStatus"@en ;
-    rdfs:comment "Windshield heater status. 0 - off, 1 - on"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:WindshieldHeating ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Body.Windshield.Heating.Status"@en .
-
-vsso:Height a owl:Class ;
-    rdfs:label "Height"@en ;
-    rdfs:comment "Overall vehicle height."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Height"@en .
-
-vsso:HoodIsOpen a owl:Class ;
-    rdfs:label "HoodIsOpen"@en ;
-    rdfs:comment "hood open or closed. True = Open. False = Closed"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BodyHood ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Body.Hood.IsOpen"@en .
-
-vsso:HornIsActive a owl:Class ;
-    rdfs:label "HornIsActive"@en ;
-    rdfs:comment "Horn active or inactive. True = Active. False = Inactive."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BodyHorn ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Body.Horn.IsActive"@en .
-
-vsso:IdentifierIssuer a owl:Class ;
-    rdfs:label "IdentifierIssuer"@en ;
-    rdfs:comment "Unique Issuer for the authentification of the occupant. E.g. https://accounts.funcorp.com"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OccupantIdentifier ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.Occupant.Identifier.Issuer"@en .
-
-vsso:IdentifierSubject a owl:Class ;
-    rdfs:label "IdentifierSubject"@en ;
-    rdfs:comment "Subject for the authentification of the occupant. E.g. UserID 7331677"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OccupantIdentifier ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.Occupant.Identifier.Subject"@en .
-
-vsso:IdleTime a owl:Class ;
-    rdfs:label "IdleTime"@en ;
-    rdfs:comment "Accumulated idle time in seconds."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.IdleTime"@en .
-
-vsso:IgnitionOffTime a owl:Class ;
-    rdfs:label "IgnitionOffTime"@en ;
-    rdfs:comment "Accumulated ignition off time in seconds."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.IgnitionOffTime"@en .
-
-vsso:IgnitionOn a owl:Class ;
-    rdfs:label "IgnitionOn"@en ;
-    rdfs:comment "Indicates whether the vehicle ignition is on or off."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.IgnitionOn"@en .
-
-vsso:IgnitionOnTime a owl:Class ;
-    rdfs:label "IgnitionOnTime"@en ;
-    rdfs:comment "Accumulated ignition on time in seconds."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.IgnitionOnTime"@en .
-
-vsso:IsMoving a owl:Class ;
-    rdfs:label "IsMoving"@en ;
-    rdfs:comment "Indicates whether the vehicle is stationary or moving"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.IsMoving"@en .
-
-vsso:LaneDepartureDetectionError a owl:Class ;
-    rdfs:label "LaneDepartureDetectionError"@en ;
-    rdfs:comment "Indicates if lane departure system incurred an error condition. True = Error. False = No Error."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ADASLaneDepartureDetection ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.ADAS.LaneDepartureDetection.Error"@en .
-
-vsso:LaneDepartureDetectionIsActive a owl:Class ;
-    rdfs:label "LaneDepartureDetectionIsActive"@en ;
-    rdfs:comment "Indicates if lane departure detection system is enabled. True = Enabled. False = Disabled."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ADASLaneDepartureDetection ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.ADAS.LaneDepartureDetection.IsActive"@en .
-
-vsso:LaneDepartureDetectionWarning a owl:Class ;
-    rdfs:label "LaneDepartureDetectionWarning"@en ;
-    rdfs:comment "Indicates if lane departure detection registered a lane departure"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ADASLaneDepartureDetection ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.ADAS.LaneDepartureDetection.Warning"@en .
-
-vsso:Length a owl:Class ;
-    rdfs:label "Length"@en ;
-    rdfs:comment "Overall vehicle length."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Length"@en .
-
-vsso:LightsAmbientLight a owl:Class ;
-    rdfs:label "LightsAmbientLight"@en ;
-    rdfs:comment "How much ambient light is detected in cabin. 0 = No ambient light. 100 = Full brightness"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinLights ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Lights.AmbientLight"@en .
-
-vsso:LightsIsBackupOn a owl:Class ;
-    rdfs:label "LightsIsBackupOn"@en ;
-    rdfs:comment "Is backup (reverse) light on"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BodyLights ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Body.Lights.IsBackupOn"@en .
-
-vsso:LightsIsBrakeOn a owl:Class ;
-    rdfs:label "LightsIsBrakeOn"@en ;
-    rdfs:comment "Is brake light on"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BodyLights ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Body.Lights.IsBrakeOn"@en .
-
-vsso:LightsIsDomeOn a owl:Class ;
-    rdfs:label "LightsIsDomeOn"@en ;
-    rdfs:comment "Is central dome light light on"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinLights ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Lights.IsDomeOn"@en .
-
-vsso:LightsIsFrontFogOn a owl:Class ;
-    rdfs:label "LightsIsFrontFogOn"@en ;
-    rdfs:comment "Is front fog light on"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BodyLights ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Body.Lights.IsFrontFogOn"@en .
-
-vsso:LightsIsGloveBoxOn a owl:Class ;
-    rdfs:label "LightsIsGloveBoxOn"@en ;
-    rdfs:comment "Is glove box light on"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinLights ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Lights.IsGloveBoxOn"@en .
-
-vsso:LightsIsHazardOn a owl:Class ;
-    rdfs:label "LightsIsHazardOn"@en ;
-    rdfs:comment "Are hazards on"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BodyLights ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Body.Lights.IsHazardOn"@en .
-
-vsso:LightsIsHighBeamOn a owl:Class ;
-    rdfs:label "LightsIsHighBeamOn"@en ;
-    rdfs:comment "Is high beam on"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BodyLights ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Body.Lights.IsHighBeamOn"@en .
-
-vsso:LightsIsLeftIndicatorOn a owl:Class ;
-    rdfs:label "LightsIsLeftIndicatorOn"@en ;
-    rdfs:comment "Is left indicator flashing"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BodyLights ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Body.Lights.IsLeftIndicatorOn"@en .
-
-vsso:LightsIsLowBeamOn a owl:Class ;
-    rdfs:label "LightsIsLowBeamOn"@en ;
-    rdfs:comment "Is low beam on"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BodyLights ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Body.Lights.IsLowBeamOn"@en .
-
-vsso:LightsIsParkingOn a owl:Class ;
-    rdfs:label "LightsIsParkingOn"@en ;
-    rdfs:comment "Is parking light on"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BodyLights ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Body.Lights.IsParkingOn"@en .
-
-vsso:LightsIsRearFogOn a owl:Class ;
-    rdfs:label "LightsIsRearFogOn"@en ;
-    rdfs:comment "Is rear fog light on"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BodyLights ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Body.Lights.IsRearFogOn"@en .
-
-vsso:LightsIsRightIndicatorOn a owl:Class ;
-    rdfs:label "LightsIsRightIndicatorOn"@en ;
-    rdfs:comment "Is right indicator flashing"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BodyLights ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Body.Lights.IsRightIndicatorOn"@en .
-
-vsso:LightsIsRunningOn a owl:Class ;
-    rdfs:label "LightsIsRunningOn"@en ;
-    rdfs:comment "Are running lights on"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BodyLights ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Body.Lights.IsRunningOn"@en .
-
-vsso:LightsIsTrunkOn a owl:Class ;
-    rdfs:label "LightsIsTrunkOn"@en ;
-    rdfs:comment "Is trunk light light on"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinLights ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Lights.IsTrunkOn"@en .
-
-vsso:LightsLightIntensity a owl:Class ;
-    rdfs:label "LightsLightIntensity"@en ;
-    rdfs:comment "Intensity of the interior lights. 0 = Off. 100 = Full brightness."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinLights ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Lights.LightIntensity"@en .
-
-vsso:LowVoltageSystemState a owl:Class ;
-    rdfs:label "LowVoltageSystemState"@en ;
-    rdfs:comment "State of the supply voltage of the control units (usually 12V)."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.LowVoltageSystemState"@en .
-
-vsso:LumbarDeflate a owl:Class ;
-    rdfs:label "LumbarDeflate"@en ;
-    rdfs:comment "Lumbar deflation switch engaged (SingleSeat.Lumbar.Inflation)"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SwitchLumbar ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.Switch.Lumbar.Deflate"@en .
-
-vsso:LumbarDown a owl:Class ;
-    rdfs:label "LumbarDown"@en ;
-    rdfs:comment "Lumbar down switch engaged (SingleSeat.Lumbar.Height)"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SwitchLumbar ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.Switch.Lumbar.Down"@en .
-
-vsso:LumbarHeight a owl:Class ;
-    rdfs:label "LumbarHeight"@en ;
-    rdfs:comment "Lumbar support position. 0 = Lowermost. 255 = Uppermost."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SeatLumbar ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.Lumbar.Height"@en .
-
-vsso:LumbarInflate a owl:Class ;
-    rdfs:label "LumbarInflate"@en ;
-    rdfs:comment "Lumbar inflation switch engaged (SingleSeat.Lumbar.Inflation)"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SwitchLumbar ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.Switch.Lumbar.Inflate"@en .
-
-vsso:LumbarInflation a owl:Class ;
-    rdfs:label "LumbarInflation"@en ;
-    rdfs:comment "Lumbar support inflation. 0 = Fully deflated. 255 = Fully inflated."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SeatLumbar ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.Lumbar.Inflation"@en .
-
-vsso:LumbarUp a owl:Class ;
-    rdfs:label "LumbarUp"@en ;
-    rdfs:comment "Lumbar up switch engaged (SingleSeat.Lumbar.Height)"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SwitchLumbar ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.Switch.Lumbar.Up"@en .
-
-vsso:MassageDecrease a owl:Class ;
-    rdfs:label "MassageDecrease"@en ;
-    rdfs:comment "Decrease massage level switch engaged (SingleSeat.Massage)"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SwitchMassage ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.Switch.Massage.Decrease"@en .
-
-vsso:MassageIncrease a owl:Class ;
-    rdfs:label "MassageIncrease"@en ;
-    rdfs:comment "Increase massage level switch engaged (SingleSeat.Massage)"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SwitchMassage ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.Switch.Massage.Increase"@en .
-
-vsso:MaxTowBallWeight a owl:Class ;
-    rdfs:label "MaxTowBallWeight"@en ;
-    rdfs:comment "Maximum vertical weight on the tow ball of a trailer."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.MaxTowBallWeight"@en .
-
-vsso:MaxTowWeight a owl:Class ;
-    rdfs:label "MaxTowWeight"@en ;
-    rdfs:comment "Maximum weight of trailer."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.MaxTowWeight"@en .
-
-vsso:MediaAction a owl:Class ;
-    rdfs:label "MediaAction"@en ;
-    rdfs:comment "Tells if the media was"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:InfotainmentMedia ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Infotainment.Media.Action"@en .
-
-vsso:MediaDeclinedURI a owl:Class ;
-    rdfs:label "MediaDeclinedURI"@en ;
-    rdfs:comment "URI of suggested media that was declined"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:InfotainmentMedia ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Infotainment.Media.DeclinedURI"@en .
-
-vsso:MediaSelectedURI a owl:Class ;
-    rdfs:label "MediaSelectedURI"@en ;
-    rdfs:comment "URI of suggested media that was selected"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:InfotainmentMedia ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Infotainment.Media.SelectedURI"@en .
-
-vsso:MediaVolume a owl:Class ;
-    rdfs:label "MediaVolume"@en ;
-    rdfs:comment "Current Media Volume"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:InfotainmentMedia ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Infotainment.Media.Volume"@en .
-
-vsso:MirrorsHeatingStatus a owl:Class ;
-    rdfs:label "MirrorsHeatingStatus"@en ;
-    rdfs:comment "Mirror Heater on or off. True = Heater On. False = Heater Off."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:MirrorsHeating ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Body.Mirrors.Heating.Status"@en .
-
-vsso:MirrorsPan a owl:Class ;
-    rdfs:label "MirrorsPan"@en ;
-    rdfs:comment "Mirror pan as a percent. 0 = Center Position. 100 = Fully Left Position. -100 = Fully Right Position."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BodyMirrors ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Body.Mirrors.Pan"@en .
-
-vsso:MirrorsTilt a owl:Class ;
-    rdfs:label "MirrorsTilt"@en ;
-    rdfs:comment "Mirror tilt as a percent. 0 = Center Position. 100 = Fully Upward Position. -100 = Fully Downward Position."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BodyMirrors ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Body.Mirrors.Tilt"@en .
-
-vsso:MotorCoolantTemperature a owl:Class ;
-    rdfs:label "MotorCoolantTemperature"@en ;
-    rdfs:comment "Motor coolant temperature (if applicable)."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ElectricMotorMotor ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.ElectricMotor.Motor.CoolantTemperature"@en .
-
-vsso:MotorPower a owl:Class ;
-    rdfs:label "MotorPower"@en ;
-    rdfs:comment "Current motor power output. Negative values indicate regen mode."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ElectricMotorMotor ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.ElectricMotor.Motor.Power"@en .
-
-vsso:MotorRpm a owl:Class ;
-    rdfs:label "MotorRpm"@en ;
-    rdfs:comment "Motor rotational speed measured as rotations per minute. Negative values indicate reverse driving mode."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ElectricMotorMotor ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.ElectricMotor.Motor.Rpm"@en .
-
-vsso:MotorTemperature a owl:Class ;
-    rdfs:label "MotorTemperature"@en ;
-    rdfs:comment "Motor temperature."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ElectricMotorMotor ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.ElectricMotor.Motor.Temperature"@en .
-
-vsso:MotorTorque a owl:Class ;
-    rdfs:label "MotorTorque"@en ;
-    rdfs:comment "Current motor torque. Negative values indicate regen mode."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ElectricMotorMotor ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.ElectricMotor.Motor.Torque"@en .
-
-vsso:NavigationCurrentLocationAccuracy a owl:Class ;
-    rdfs:label "NavigationCurrentLocationAccuracy"@en ;
-    rdfs:comment "Accuracy level of the latitude and longitude coordinates in meters."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:NavigationCurrentLocation ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Infotainment.Navigation.CurrentLocation.Accuracy"@en .
-
-vsso:NavigationCurrentLocationAltitude a owl:Class ;
-    rdfs:label "NavigationCurrentLocationAltitude"@en ;
-    rdfs:comment "Current elevation of the position in meters."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:NavigationCurrentLocation ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Infotainment.Navigation.CurrentLocation.Altitude"@en .
-
-vsso:NavigationCurrentLocationHeading a owl:Class ;
-    rdfs:label "NavigationCurrentLocationHeading"@en ;
-    rdfs:comment "Current magnetic compass heading, in degrees."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:NavigationCurrentLocation ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Infotainment.Navigation.CurrentLocation.Heading"@en .
-
-vsso:NavigationCurrentLocationLatitude a owl:Class ;
-    rdfs:label "NavigationCurrentLocationLatitude"@en ;
-    rdfs:comment "Current latitude of vehicle, as reported by GPS."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:NavigationCurrentLocation ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Infotainment.Navigation.CurrentLocation.Latitude"@en .
-
-vsso:NavigationCurrentLocationLongitude a owl:Class ;
-    rdfs:label "NavigationCurrentLocationLongitude"@en ;
-    rdfs:comment "Current longitude of vehicle, as reported by GPS."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:NavigationCurrentLocation ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Infotainment.Navigation.CurrentLocation.Longitude"@en .
-
-vsso:O2ShortTermFuelTrim a owl:Class ;
-    rdfs:label "O2ShortTermFuelTrim"@en ;
-    rdfs:comment "PID 1x (byte B) - Short term fuel trim"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBDO2 ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.O2.ShortTermFuelTrim"@en .
-
-vsso:O2Voltage a owl:Class ;
-    rdfs:label "O2Voltage"@en ;
-    rdfs:comment "PID 1x (byte A) - Sensor voltage"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBDO2 ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.O2.Voltage"@en .
-
-vsso:O2WRCurrent a owl:Class ;
-    rdfs:label "O2WRCurrent"@en ;
-    rdfs:comment "PID 3x (byte CD) - Current for wide range/band oxygen sensor"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBDO2WR ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.O2WR.Current"@en .
-
-vsso:O2WRLambda a owl:Class ;
-    rdfs:label "O2WRLambda"@en ;
-    rdfs:comment "PID 2x (byte AB) and PID 3x (byte AB) - Lambda for wide range/band oxygen sensor"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBDO2WR ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.O2WR.Lambda"@en .
-
-vsso:O2WRVoltage a owl:Class ;
-    rdfs:label "O2WRVoltage"@en ;
-    rdfs:comment "PID 2x (byte CD) - Voltage for wide range/band oxygen sensor"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBDO2WR ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.O2WR.Voltage"@en .
-
-vsso:OBDAbsoluteLoad a owl:Class ;
-    rdfs:label "OBDAbsoluteLoad"@en ;
-    rdfs:comment "PID 43 - Absolute load value"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.AbsoluteLoad"@en .
-
-vsso:OBDAcceleratorPositionD a owl:Class ;
-    rdfs:label "OBDAcceleratorPositionD"@en ;
-    rdfs:comment "PID 49 - Accelerator pedal position D"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.AcceleratorPositionD"@en .
-
-vsso:OBDAcceleratorPositionE a owl:Class ;
-    rdfs:label "OBDAcceleratorPositionE"@en ;
-    rdfs:comment "PID 4A - Accelerator pedal position E"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.AcceleratorPositionE"@en .
-
-vsso:OBDAcceleratorPositionF a owl:Class ;
-    rdfs:label "OBDAcceleratorPositionF"@en ;
-    rdfs:comment "PID 4B - Accelerator pedal position F"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.AcceleratorPositionF"@en .
-
-vsso:OBDAirStatus a owl:Class ;
-    rdfs:label "OBDAirStatus"@en ;
-    rdfs:comment "PID 12 - Secondary air status"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.AirStatus"@en .
-
-vsso:OBDAmbientAirTemperature a owl:Class ;
-    rdfs:label "OBDAmbientAirTemperature"@en ;
-    rdfs:comment "PID 46 - Ambient air temperature"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.AmbientAirTemperature"@en .
-
-vsso:OBDAuxInputStatus a owl:Class ;
-    rdfs:label "OBDAuxInputStatus"@en ;
-    rdfs:comment "PID 1E - Auxiliary input status (power take off)"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.AuxInputStatus"@en .
-
-vsso:OBDBarometricPressure a owl:Class ;
-    rdfs:label "OBDBarometricPressure"@en ;
-    rdfs:comment "PID 33 - Barometric pressure"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.BarometricPressure"@en .
-
-vsso:OBDCommandedEGR a owl:Class ;
-    rdfs:label "OBDCommandedEGR"@en ;
-    rdfs:comment "PID 2C - Commanded exhaust gas recirculation (EGR)"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.CommandedEGR"@en .
-
-vsso:OBDCommandedEVAP a owl:Class ;
-    rdfs:label "OBDCommandedEVAP"@en ;
-    rdfs:comment "PID 2E - Commanded evaporative purge (EVAP) valve"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.CommandedEVAP"@en .
-
-vsso:OBDCommandedEquivalenceRatio a owl:Class ;
-    rdfs:label "OBDCommandedEquivalenceRatio"@en ;
-    rdfs:comment "PID 44 - Commanded equivalence ratio"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.CommandedEquivalenceRatio"@en .
-
-vsso:OBDControlModuleVoltage a owl:Class ;
-    rdfs:label "OBDControlModuleVoltage"@en ;
-    rdfs:comment "PID 42 - Control module voltage"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.ControlModuleVoltage"@en .
-
-vsso:OBDCoolantTemperature a owl:Class ;
-    rdfs:label "OBDCoolantTemperature"@en ;
-    rdfs:comment "PID 05 - Coolant temperature"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.CoolantTemperature"@en .
-
-vsso:OBDDTCList a owl:Class ;
-    rdfs:label "OBDDTCList"@en ;
-    rdfs:comment "List of currently active DTCs formatted according OBD II (SAE-J2012DA_201812) standard ([P|C|B|U]XXXXX )"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.DTCList"@en .
-
-vsso:OBDDistanceSinceDTCClear a owl:Class ;
-    rdfs:label "OBDDistanceSinceDTCClear"@en ;
-    rdfs:comment "PID 31 - Distance traveled since codes cleared"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.DistanceSinceDTCClear"@en .
-
-vsso:OBDDistanceWithMIL a owl:Class ;
-    rdfs:label "OBDDistanceWithMIL"@en ;
-    rdfs:comment "PID 21 - Distance traveled with MIL on"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.DistanceWithMIL"@en .
-
-vsso:OBDEGRError a owl:Class ;
-    rdfs:label "OBDEGRError"@en ;
-    rdfs:comment "PID 2D - Exhaust gas recirculation (EGR) error"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.EGRError"@en .
-
-vsso:OBDEVAPVaporPressure a owl:Class ;
-    rdfs:label "OBDEVAPVaporPressure"@en ;
-    rdfs:comment "PID 32 - Evaporative purge (EVAP) system pressure"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.EVAPVaporPressure"@en .
-
-vsso:OBDEVAPVaporPressureAbsolute a owl:Class ;
-    rdfs:label "OBDEVAPVaporPressureAbsolute"@en ;
-    rdfs:comment "PID 53 - Absolute evaporative purge (EVAP) system pressure"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.EVAPVaporPressureAbsolute"@en .
-
-vsso:OBDEVAPVaporPressureAlternate a owl:Class ;
-    rdfs:label "OBDEVAPVaporPressureAlternate"@en ;
-    rdfs:comment "PID 54 - Alternate evaporative purge (EVAP) system pressure"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.EVAPVaporPressureAlternate"@en .
-
-vsso:OBDEngineLoad a owl:Class ;
-    rdfs:label "OBDEngineLoad"@en ;
-    rdfs:comment "PID 04 - Engine load in percent - 0 = no load, 100 = full load"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.EngineLoad"@en .
-
-vsso:OBDEngineSpeed a owl:Class ;
-    rdfs:label "OBDEngineSpeed"@en ;
-    rdfs:comment "PID 0C - Engine speed measured as rotations per minute"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.EngineSpeed"@en .
-
-vsso:OBDEthanolPercent a owl:Class ;
-    rdfs:label "OBDEthanolPercent"@en ;
-    rdfs:comment "PID 52 - Percentage of ethanol in the fuel"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.EthanolPercent"@en .
-
-vsso:OBDFreezeDTC a owl:Class ;
-    rdfs:label "OBDFreezeDTC"@en ;
-    rdfs:comment "PID 02 - DTC that triggered the freeze frame"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.FreezeDTC"@en .
-
-vsso:OBDFuelInjectionTiming a owl:Class ;
-    rdfs:label "OBDFuelInjectionTiming"@en ;
-    rdfs:comment "PID 5D - Fuel injection timing"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.FuelInjectionTiming"@en .
-
-vsso:OBDFuelLevel a owl:Class ;
-    rdfs:label "OBDFuelLevel"@en ;
-    rdfs:comment "PID 2F - Fuel level in the fuel tank"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.FuelLevel"@en .
-
-vsso:OBDFuelPressure a owl:Class ;
-    rdfs:label "OBDFuelPressure"@en ;
-    rdfs:comment "PID 0A - Fuel pressure"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.FuelPressure"@en .
-
-vsso:OBDFuelRailPressureAbsolute a owl:Class ;
-    rdfs:label "OBDFuelRailPressureAbsolute"@en ;
-    rdfs:comment "PID 59 - Absolute fuel rail pressure"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.FuelRailPressureAbsolute"@en .
-
-vsso:OBDFuelRailPressureDirect a owl:Class ;
-    rdfs:label "OBDFuelRailPressureDirect"@en ;
-    rdfs:comment "PID 23 - Fuel rail pressure direct inject"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.FuelRailPressureDirect"@en .
-
-vsso:OBDFuelRailPressureVac a owl:Class ;
-    rdfs:label "OBDFuelRailPressureVac"@en ;
-    rdfs:comment "PID 22 - Fuel rail pressure relative to vacuum"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.FuelRailPressureVac"@en .
-
-vsso:OBDFuelRate a owl:Class ;
-    rdfs:label "OBDFuelRate"@en ;
-    rdfs:comment "PID 5E - Engine fuel rate"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.FuelRate"@en .
-
-vsso:OBDFuelStatus a owl:Class ;
-    rdfs:label "OBDFuelStatus"@en ;
-    rdfs:comment "PID 03 - Fuel status"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.FuelStatus"@en .
-
-vsso:OBDFuelType a owl:Class ;
-    rdfs:label "OBDFuelType"@en ;
-    rdfs:comment "PID 51 - Fuel type"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.FuelType"@en .
-
-vsso:OBDHybridBatteryRemaining a owl:Class ;
-    rdfs:label "OBDHybridBatteryRemaining"@en ;
-    rdfs:comment "PID 5B - Remaining life of hybrid battery"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.HybridBatteryRemaining"@en .
-
-vsso:OBDIntakeTemp a owl:Class ;
-    rdfs:label "OBDIntakeTemp"@en ;
-    rdfs:comment "PID 0F - Intake temperature"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.IntakeTemp"@en .
-
-vsso:OBDLongTermFuelTrim1 a owl:Class ;
-    rdfs:label "OBDLongTermFuelTrim1"@en ;
-    rdfs:comment "PID 07 - Long Term (learned) Fuel Trim - Bank 1 - negative percent leaner, positive percent richer"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.LongTermFuelTrim1"@en .
-
-vsso:OBDLongTermFuelTrim2 a owl:Class ;
-    rdfs:label "OBDLongTermFuelTrim2"@en ;
-    rdfs:comment "PID 09 - Long Term (learned) Fuel Trim - Bank 2 - negative percent leaner, positive percent richer"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.LongTermFuelTrim2"@en .
-
-vsso:OBDLongTermO2Trim1 a owl:Class ;
-    rdfs:label "OBDLongTermO2Trim1"@en ;
-    rdfs:comment "PID 56 (byte A) - Long term secondary O2 trim - Bank 1"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.LongTermO2Trim1"@en .
-
-vsso:OBDLongTermO2Trim2 a owl:Class ;
-    rdfs:label "OBDLongTermO2Trim2"@en ;
-    rdfs:comment "PID 58 (byte A) - Long term secondary O2 trim - Bank 2"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.LongTermO2Trim2"@en .
-
-vsso:OBDLongTermO2Trim3 a owl:Class ;
-    rdfs:label "OBDLongTermO2Trim3"@en ;
-    rdfs:comment "PID 56 (byte B) - Long term secondary O2 trim - Bank 3"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.LongTermO2Trim3"@en .
-
-vsso:OBDLongTermO2Trim4 a owl:Class ;
-    rdfs:label "OBDLongTermO2Trim4"@en ;
-    rdfs:comment "PID 58 (byte B) - Long term secondary O2 trim - Bank 4"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.LongTermO2Trim4"@en .
-
-vsso:OBDMAF a owl:Class ;
-    rdfs:label "OBDMAF"@en ;
-    rdfs:comment "PID 10 - Grams of air drawn into engine per second"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.MAF"@en .
-
-vsso:OBDMAP a owl:Class ;
-    rdfs:label "OBDMAP"@en ;
-    rdfs:comment "PID 0B - Intake manifold pressure"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.MAP"@en .
-
-vsso:OBDMaxMAF a owl:Class ;
-    rdfs:label "OBDMaxMAF"@en ;
-    rdfs:comment "PID 50 - Maximum flow for mass air flow sensor"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.MaxMAF"@en .
-
-vsso:OBDOBDStandards a owl:Class ;
-    rdfs:label "OBDOBDStandards"@en ;
-    rdfs:comment "PID 1C - OBD standards this vehicle conforms to"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.OBDStandards"@en .
-
-vsso:OBDOilTemperature a owl:Class ;
-    rdfs:label "OBDOilTemperature"@en ;
-    rdfs:comment "PID 5C - Engine oil temperature"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.OilTemperature"@en .
-
-vsso:OBDOxygenSensorsIn2Banks a owl:Class ;
-    rdfs:label "OBDOxygenSensorsIn2Banks"@en ;
-    rdfs:comment "PID 13 - Presence of oxygen sensors in 2 banks. [A0..A3] == Bank 1, Sensors 1-4. [A4..A7] == Bank 2, Sensors 1-4"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.OxygenSensorsIn2Banks"@en .
-
-vsso:OBDOxygenSensorsIn4Banks a owl:Class ;
-    rdfs:label "OBDOxygenSensorsIn4Banks"@en ;
-    rdfs:comment "PID 1D - Presence of oxygen sensors in 4 banks. Similar to PID 13, but [A0..A7] == [B1S1, B1S2, B2S1, B2S2, B3S1, B3S2, B4S1, B4S2]"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.OxygenSensorsIn4Banks"@en .
-
-vsso:OBDPidsA a owl:Class ;
-    rdfs:label "OBDPidsA"@en ;
-    rdfs:comment "PID 00 - Bit array of the supported pids 01 to 20"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.PidsA"@en .
-
-vsso:OBDPidsB a owl:Class ;
-    rdfs:label "OBDPidsB"@en ;
-    rdfs:comment "PID 20 - Bit array of the supported pids 21 to 40"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.PidsB"@en .
-
-vsso:OBDPidsC a owl:Class ;
-    rdfs:label "OBDPidsC"@en ;
-    rdfs:comment "PID 40 - Bit array of the supported pids 41 to 60"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.PidsC"@en .
-
-vsso:OBDRelativeAcceleratorPosition a owl:Class ;
-    rdfs:label "OBDRelativeAcceleratorPosition"@en ;
-    rdfs:comment "PID 5A - Relative accelerator pedal position"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.RelativeAcceleratorPosition"@en .
-
-vsso:OBDRelativeThrottlePosition a owl:Class ;
-    rdfs:label "OBDRelativeThrottlePosition"@en ;
-    rdfs:comment "PID 45 - Relative throttle position"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.RelativeThrottlePosition"@en .
-
-vsso:OBDRunTime a owl:Class ;
-    rdfs:label "OBDRunTime"@en ;
-    rdfs:comment "PID 1F - Engine run time"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.RunTime"@en .
-
-vsso:OBDRunTimeMIL a owl:Class ;
-    rdfs:label "OBDRunTimeMIL"@en ;
-    rdfs:comment "PID 4D - Run time with MIL on"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.RunTimeMIL"@en .
-
-vsso:OBDShortTermFuelTrim1 a owl:Class ;
-    rdfs:label "OBDShortTermFuelTrim1"@en ;
-    rdfs:comment "PID 06 - Short Term (immediate) Fuel Trim - Bank 1 - negative percent leaner, positive percent richer"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.ShortTermFuelTrim1"@en .
-
-vsso:OBDShortTermFuelTrim2 a owl:Class ;
-    rdfs:label "OBDShortTermFuelTrim2"@en ;
-    rdfs:comment "PID 08 - Short Term (immediate) Fuel Trim - Bank 2 - negative percent leaner, positive percent richer"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.ShortTermFuelTrim2"@en .
-
-vsso:OBDShortTermO2Trim1 a owl:Class ;
-    rdfs:label "OBDShortTermO2Trim1"@en ;
-    rdfs:comment "PID 55 (byte A) - Short term secondary O2 trim - Bank 1"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.ShortTermO2Trim1"@en .
-
-vsso:OBDShortTermO2Trim2 a owl:Class ;
-    rdfs:label "OBDShortTermO2Trim2"@en ;
-    rdfs:comment "PID 57 (byte A) - Short term secondary O2 trim - Bank 2"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.ShortTermO2Trim2"@en .
-
-vsso:OBDShortTermO2Trim3 a owl:Class ;
-    rdfs:label "OBDShortTermO2Trim3"@en ;
-    rdfs:comment "PID 55 (byte B) - Short term secondary O2 trim - Bank 3"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.ShortTermO2Trim3"@en .
-
-vsso:OBDShortTermO2Trim4 a owl:Class ;
-    rdfs:label "OBDShortTermO2Trim4"@en ;
-    rdfs:comment "PID 57 (byte B) - Short term secondary O2 trim - Bank 4"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.ShortTermO2Trim4"@en .
-
-vsso:OBDSpeed a owl:Class ;
-    rdfs:label "OBDSpeed"@en ;
-    rdfs:comment "PID 0D - Vehicle speed"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.Speed"@en .
-
-vsso:OBDThrottleActuator a owl:Class ;
-    rdfs:label "OBDThrottleActuator"@en ;
-    rdfs:comment "PID 4C - Commanded throttle actuator"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.ThrottleActuator"@en .
-
-vsso:OBDThrottlePosition a owl:Class ;
-    rdfs:label "OBDThrottlePosition"@en ;
-    rdfs:comment "PID 11 - Throttle position - 0 = closed throttle, 100 = open throttle"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.ThrottlePosition"@en .
-
-vsso:OBDThrottlePositionB a owl:Class ;
-    rdfs:label "OBDThrottlePositionB"@en ;
-    rdfs:comment "PID 47 - Absolute throttle position B"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.ThrottlePositionB"@en .
-
-vsso:OBDThrottlePositionC a owl:Class ;
-    rdfs:label "OBDThrottlePositionC"@en ;
-    rdfs:comment "PID 48 - Absolute throttle position C"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.ThrottlePositionC"@en .
-
-vsso:OBDTimeSinceDTCCleared a owl:Class ;
-    rdfs:label "OBDTimeSinceDTCCleared"@en ;
-    rdfs:comment "PID 4E - Time since trouble codes cleared"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.TimeSinceDTCCleared"@en .
-
-vsso:OBDTimingAdvance a owl:Class ;
-    rdfs:label "OBDTimingAdvance"@en ;
-    rdfs:comment "PID 0E - Time advance"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.TimingAdvance"@en .
-
-vsso:OBDWarmupsSinceDTCClear a owl:Class ;
-    rdfs:label "OBDWarmupsSinceDTCClear"@en ;
-    rdfs:comment "PID 30 - Number of warm-ups since codes cleared"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.WarmupsSinceDTCClear"@en .
-
-vsso:ObstacleDetectionError a owl:Class ;
-    rdfs:label "ObstacleDetectionError"@en ;
-    rdfs:comment "Indicates if obstacle sensor system incurred an error condition. True = Error. False = No Error."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ADASObstacleDetection ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.ADAS.ObstacleDetection.Error"@en .
-
-vsso:ObstacleDetectionIsActive a owl:Class ;
-    rdfs:label "ObstacleDetectionIsActive"@en ;
-    rdfs:comment "Indicates if obstacle sensor system is enabled. True = Enabled. False = Disabled."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ADASObstacleDetection ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.ADAS.ObstacleDetection.IsActive"@en .
-
-vsso:ParkingBrakeIsEngaged a owl:Class ;
-    rdfs:label "ParkingBrakeIsEngaged"@en ;
-    rdfs:comment "Parking brake status. True = Parking Brake is Engaged. False = Parking Brake is not Engaged."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ChassisParkingBrake ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Chassis.ParkingBrake.IsEngaged"@en .
-
-vsso:PlayedAlbum a owl:Class ;
-    rdfs:label "PlayedAlbum"@en ;
-    rdfs:comment "Name of album being played"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:MediaPlayed ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Infotainment.Media.Played.Album"@en .
-
-vsso:PlayedArtist a owl:Class ;
-    rdfs:label "PlayedArtist"@en ;
-    rdfs:comment "Name of artist being played"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:MediaPlayed ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Infotainment.Media.Played.Artist"@en .
-
-vsso:PlayedSource a owl:Class ;
-    rdfs:label "PlayedSource"@en ;
-    rdfs:comment "Media selected for playback"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:MediaPlayed ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Infotainment.Media.Played.Source"@en .
-
-vsso:PlayedTrack a owl:Class ;
-    rdfs:label "PlayedTrack"@en ;
-    rdfs:comment "Name of track being played"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:MediaPlayed ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Infotainment.Media.Played.Track"@en .
-
-vsso:PlayedURI a owl:Class ;
-    rdfs:label "PlayedURI"@en ;
-    rdfs:comment "User Resource associated with the media"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:MediaPlayed ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Infotainment.Media.Played.URI"@en .
-
-vsso:PowertrainAccumulatedBrakingEnergy a owl:Class ;
-    rdfs:label "PowertrainAccumulatedBrakingEnergy"@en ;
-    rdfs:comment "The accumulated energy from regenerative braking over lifetime."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Powertrain ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.AccumulatedBrakingEnergy"@en .
-
-vsso:PowertrainRange a owl:Class ;
-    rdfs:label "PowertrainRange"@en ;
-    rdfs:comment "Remaining range in meters using all energy sources available in the vehicle."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Powertrain ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Range"@en .
-
-vsso:Private a owl:Class ;
-    rdfs:label "Private"@en ;
-    rdfs:comment "Uncontrolled branch where non-public signals can be defined."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Private"@en .
-
-vsso:Raindetectionintensity a owl:Class ;
-    rdfs:label "Raindetectionintensity"@en ;
-    rdfs:comment "Rain intensity. 0 = Dry, No Rain. 100 = Covered."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BodyRaindetection ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Body.Raindetection.intensity"@en .
-
-vsso:RearShadePosition a owl:Class ;
-    rdfs:label "RearShadePosition"@en ;
-    rdfs:comment "Position of window blind. 0 = Fully retracted. 100 = Fully deployed."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinRearShade ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.RearShade.Position"@en .
-
-vsso:RearShadeSwitch a owl:Class ;
-    rdfs:label "RearShadeSwitch"@en ;
-    rdfs:comment "Switch controlling sliding action such as window, sunroof, or blind."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinRearShade ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.RearShade.Switch"@en .
-
-vsso:RearviewMirrorDimmingLevel a owl:Class ;
-    rdfs:label "RearviewMirrorDimmingLevel"@en ;
-    rdfs:comment "Dimming level of rearview mirror. 0 = undimmed. 100 = fully dimmed"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinRearviewMirror ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.RearviewMirror.DimmingLevel"@en .
-
-vsso:ReclineBackward a owl:Class ;
-    rdfs:label "ReclineBackward"@en ;
-    rdfs:comment "Seatback recline backward switch engaged (SingleSeat.Recline)"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SwitchRecline ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.Switch.Recline.Backward"@en .
-
-vsso:ReclineForward a owl:Class ;
-    rdfs:label "ReclineForward"@en ;
-    rdfs:comment "Seatback recline forward switch engaged (SingleSeat.Recline)"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SwitchRecline ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.Switch.Recline.Forward"@en .
-
-vsso:RoofLoad a owl:Class ;
-    rdfs:label "RoofLoad"@en ;
-    rdfs:comment "The permitted total weight of cargo and installations (e.g. a roof rack) on top of the vehicle."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.RoofLoad"@en .
-
-vsso:SeatHasPassenger a owl:Class ;
-    rdfs:label "SeatHasPassenger"@en ;
-    rdfs:comment "Does the seat have a passenger in it."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinSeat ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.HasPassenger"@en .
-
-vsso:SeatHeating a owl:Class ;
-    rdfs:label "SeatHeating"@en ;
-    rdfs:comment "Seat cooling / heating. 0 = off. -100 = max cold. +100 = max heat."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinSeat ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.Heating"@en .
-
-vsso:SeatHeight a owl:Class ;
-    rdfs:label "SeatHeight"@en ;
-    rdfs:comment "Seat vertical position. 0 = Lowermost. 1000 = Uppermost."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinSeat ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.Height"@en .
-
-vsso:SeatIsBelted a owl:Class ;
-    rdfs:label "SeatIsBelted"@en ;
-    rdfs:comment "Is the belt engaged."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinSeat ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.IsBelted"@en .
-
-vsso:SeatMassage a owl:Class ;
-    rdfs:label "SeatMassage"@en ;
-    rdfs:comment "Seat massage level. 0 = off. 100 = max massage."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinSeat ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.Massage"@en .
-
-vsso:SeatPosition a owl:Class ;
-    rdfs:label "SeatPosition"@en ;
-    rdfs:comment "Seat horizontal position. 0 = Frontmost. 1000 = Rearmost."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinSeat ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.Position"@en .
-
-vsso:SeatRecline a owl:Class ;
-    rdfs:label "SeatRecline"@en ;
-    rdfs:comment "Recline level. -90 = Max forward recline. 90 max backward recline."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinSeat ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.Recline"@en .
-
-vsso:ServiceDistanceToService a owl:Class ;
-    rdfs:label "ServiceDistanceToService"@en ;
-    rdfs:comment "Remaining distance to service (of any kind). Negative values indicate service overdue."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Service ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Service.DistanceToService"@en .
-
-vsso:ServiceServiceDue a owl:Class ;
-    rdfs:label "ServiceServiceDue"@en ;
-    rdfs:comment "Indicates if vehicle needs service (of any kind). True = Service needed now or in the near future. False = No known need for service."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Service ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Service.ServiceDue"@en .
-
-vsso:ServiceTimeToService a owl:Class ;
-    rdfs:label "ServiceTimeToService"@en ;
-    rdfs:comment "Remaining time to service (of any kind). Negative values indicate service overdue."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Service ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Service.TimeToService"@en .
-
-vsso:ShadePosition a owl:Class ;
-    rdfs:label "ShadePosition"@en ;
-    rdfs:comment "Position of window blind. 0 = Fully retracted. 100 = Fully deployed."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SunroofShade ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Sunroof.Shade.Position"@en .
-
-vsso:ShadeSwitch a owl:Class ;
-    rdfs:label "ShadeSwitch"@en ;
-    rdfs:comment "Switch controlling sliding action such as window, sunroof, or blind."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SunroofShade ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Sunroof.Shade.Switch"@en .
-
-vsso:SideBolsterDeflate a owl:Class ;
-    rdfs:label "SideBolsterDeflate"@en ;
-    rdfs:comment "Side bolster deflation switch engaged (SingleSeat.SideBolster.Inflation)"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SwitchSideBolster ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.Switch.SideBolster.Deflate"@en .
-
-vsso:SideBolsterInflate a owl:Class ;
-    rdfs:label "SideBolsterInflate"@en ;
-    rdfs:comment "Side bolster inflation switch engaged (SingleSeat.SideBolster.Inflation)"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SwitchSideBolster ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.Switch.SideBolster.Inflate"@en .
-
-vsso:SideBolsterInflation a owl:Class ;
-    rdfs:label "SideBolsterInflation"@en ;
-    rdfs:comment "Side bolster support inflation. 0 = Fully deflated. 255 = Fully inflated."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SeatSideBolster ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.SideBolster.Inflation"@en .
-
-vsso:Speed a owl:Class ;
-    rdfs:label "Speed"@en ;
-    rdfs:comment "Vehicle speed"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Speed"@en .
-
-vsso:SpotlightIsLeftOn a owl:Class ;
-    rdfs:label "SpotlightIsLeftOn"@en ;
-    rdfs:comment "Is light on the left side switched on"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:LightsSpotlight ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Lights.Spotlight.IsLeftOn"@en .
-
-vsso:SpotlightIsRightOn a owl:Class ;
-    rdfs:label "SpotlightIsRightOn"@en ;
-    rdfs:comment "Is light on the right side switched on"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:LightsSpotlight ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Lights.Spotlight.IsRightOn"@en .
-
-vsso:SpotlightIsSharedOn a owl:Class ;
-    rdfs:label "SpotlightIsSharedOn"@en ;
-    rdfs:comment "Is a shared light across a specific row on"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:LightsSpotlight ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Lights.Spotlight.IsSharedOn"@en .
-
-vsso:StateOfChargeCurrent a owl:Class ;
-    rdfs:label "StateOfChargeCurrent"@en ;
-    rdfs:comment "Physical state of charge of the high voltage battery. This is not necessarily the state of charge being displayed to the customer."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BatteryStateOfCharge ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Battery.StateOfCharge.Current"@en .
-
-vsso:StateOfChargeDisplayed a owl:Class ;
-    rdfs:label "StateOfChargeDisplayed"@en ;
-    rdfs:comment "State of charge displayed to the customer."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BatteryStateOfCharge ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Battery.StateOfCharge.Displayed"@en .
-
-vsso:StateOfChargeTarget a owl:Class ;
-    rdfs:label "StateOfChargeTarget"@en ;
-    rdfs:comment "Target state of charge set (eg. by customer)."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BatteryStateOfCharge ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Battery.StateOfCharge.Target"@en .
-
-vsso:StationAirDistribution a owl:Class ;
-    rdfs:label "StationAirDistribution"@en ;
-    rdfs:comment "Direction of airstream"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:HVACStation ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.HVAC.Station.AirDistribution"@en .
-
-vsso:StationFanSpeed a owl:Class ;
-    rdfs:label "StationFanSpeed"@en ;
-    rdfs:comment "Fan Speed, 0 = off. 100 = max"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:HVACStation ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.HVAC.Station.FanSpeed"@en .
-
-vsso:StationTemperature a owl:Class ;
-    rdfs:label "StationTemperature"@en ;
-    rdfs:comment "Temperature"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:HVACStation ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.HVAC.Station.Temperature"@en .
-
-vsso:StatusDTCCount a owl:Class ;
-    rdfs:label "StatusDTCCount"@en ;
-    rdfs:comment "Number of sensor Trouble Codes (DTC)"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBDStatus ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.Status.DTCCount"@en .
-
-vsso:StatusIgnitionType a owl:Class ;
-    rdfs:label "StatusIgnitionType"@en ;
-    rdfs:comment "Type of the ignition for ICE - spark = spark plug ignition, compression = self-igniting (Diesel engines)"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBDStatus ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.Status.IgnitionType"@en .
-
-vsso:StatusMIL a owl:Class ;
-    rdfs:label "StatusMIL"@en ;
-    rdfs:comment "Malfunction Indicator Light (MIL) False = Off, True = On"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBDStatus ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.OBD.Status.MIL"@en .
-
-vsso:SteeringWheelAngle a owl:Class ;
-    rdfs:label "SteeringWheelAngle"@en ;
-    rdfs:comment "Steering wheel angle. Positive = degrees to the left. Negative = degrees to the right."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ChassisSteeringWheel ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Chassis.SteeringWheel.Angle"@en .
-
-vsso:SteeringWheelExtension a owl:Class ;
-    rdfs:label "SteeringWheelExtension"@en ;
-    rdfs:comment "Steering wheel column extension from dashboard. 0 = Closest to dashboard. 100 = Furthest from dashboard."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ChassisSteeringWheel ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Chassis.SteeringWheel.Extension"@en .
-
-vsso:SteeringWheelPosition a owl:Class ;
-    rdfs:label "SteeringWheelPosition"@en ;
-    rdfs:comment "Position of the steering wheel on the left or right side of the vehicle."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ChassisSteeringWheel ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Chassis.SteeringWheel.Position"@en .
-
-vsso:SteeringWheelTilt a owl:Class ;
-    rdfs:label "SteeringWheelTilt"@en ;
-    rdfs:comment "Steering wheel column tilt. 0 = Lowest position. 100 = Highest position."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ChassisSteeringWheel ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Chassis.SteeringWheel.Tilt"@en .
-
-vsso:SunroofPosition a owl:Class ;
-    rdfs:label "SunroofPosition"@en ;
-    rdfs:comment "Sunroof position. 0 = Fully closed 100 = Fully opened. -100 = Fully tilted"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinSunroof ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Sunroof.Position"@en .
-
-vsso:SunroofSwitch a owl:Class ;
-    rdfs:label "SunroofSwitch"@en ;
-    rdfs:comment "Switch controlling sliding action such as window, sunroof, or shade."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinSunroof ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Sunroof.Switch"@en .
-
-vsso:SwitchBackward a owl:Class ;
-    rdfs:label "SwitchBackward"@en ;
-    rdfs:comment "Seat backward switch engaged (SingleSeat.Position)"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SeatSwitch ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.Switch.Backward"@en .
-
-vsso:SwitchCooler a owl:Class ;
-    rdfs:label "SwitchCooler"@en ;
-    rdfs:comment "Cooler switch for Seat heater (SingleSeat.Heating)"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SeatSwitch ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.Switch.Cooler"@en .
-
-vsso:SwitchDown a owl:Class ;
-    rdfs:label "SwitchDown"@en ;
-    rdfs:comment "Seat down switch engaged (SingleSeat.Height)"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SeatSwitch ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.Switch.Down"@en .
-
-vsso:SwitchForward a owl:Class ;
-    rdfs:label "SwitchForward"@en ;
-    rdfs:comment "Seat forward switch engaged (SingleSeat.Position)"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SeatSwitch ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.Switch.Forward"@en .
-
-vsso:SwitchUp a owl:Class ;
-    rdfs:label "SwitchUp"@en ;
-    rdfs:comment "Seat up switch engaged (SingleSeat.Height)"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SeatSwitch ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.Switch.Up"@en .
-
-vsso:SwitchWarmer a owl:Class ;
-    rdfs:label "SwitchWarmer"@en ;
-    rdfs:comment "Warmer switch for Seat heater (SingleSeat.Heating)"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SeatSwitch ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Seat.Switch.Warmer"@en .
-
-vsso:TCSError a owl:Class ;
-    rdfs:label "TCSError"@en ;
-    rdfs:comment "Indicates if TCS incurred an error condition. True = Error. False = No Error."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ADASTCS ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.ADAS.TCS.Error"@en .
-
-vsso:TCSIsActive a owl:Class ;
-    rdfs:label "TCSIsActive"@en ;
-    rdfs:comment "Indicates if TCS is enabled. True = Enabled. False = Disabled."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ADASTCS ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.ADAS.TCS.IsActive"@en .
-
-vsso:TCSIsEngaged a owl:Class ;
-    rdfs:label "TCSIsEngaged"@en ;
-    rdfs:comment "Indicates if TCS is currently regulating traction. True = Engaged. False = Not Engaged."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ADASTCS ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.ADAS.TCS.IsEngaged"@en .
-
-vsso:TimerMode a owl:Class ;
-    rdfs:label "TimerMode"@en ;
-    rdfs:comment "Defines whether Timer.Time is defining start- or endtime of a charging action; departuretime denotes that target time should be taken from vehicle-level desired departure-time setting."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ChargingTimer ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Battery.Charging.Timer.Mode"@en .
-
-vsso:TimerTime a owl:Class ;
-    rdfs:label "TimerTime"@en ;
-    rdfs:comment "Time value for next charging-related action (Unix timestamp, seconds)."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ChargingTimer ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Battery.Charging.Timer.Time"@en .
-
-vsso:TirePressure a owl:Class ;
-    rdfs:label "TirePressure"@en ;
-    rdfs:comment "Tire pressure in kilo-Pascal"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:WheelTire ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Chassis.Axle.Wheel.Tire.Pressure"@en .
-
-vsso:TirePressureLow a owl:Class ;
-    rdfs:label "TirePressureLow"@en ;
-    rdfs:comment "Tire Pressure Status. True = Low tire pressure. False = Good tire pressure."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:WheelTire ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Chassis.Axle.Wheel.Tire.PressureLow"@en .
-
-vsso:TireTemperature a owl:Class ;
-    rdfs:label "TireTemperature"@en ;
-    rdfs:comment "Tire temperature in Celsius."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:WheelTire ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Chassis.Axle.Wheel.Tire.Temperature"@en .
-
-vsso:TrailerConnected a owl:Class ;
-    rdfs:label "TrailerConnected"@en ;
-    rdfs:comment "Signal indicating if trailer is connected or not."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Trailer ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Trailer.Connected"@en .
-
-vsso:TransmissionClutchWear a owl:Class ;
-    rdfs:label "TransmissionClutchWear"@en ;
-    rdfs:comment "Clutch wear as a percent. 0 = no wear. 100 = worn."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainTransmission ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Transmission.ClutchWear"@en .
-
-vsso:TransmissionCurrentGear a owl:Class ;
-    rdfs:label "TransmissionCurrentGear"@en ;
-    rdfs:comment "The current gear. 0=Neutral, 1/2/..=Forward, -1/..=Reverse"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainTransmission ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Transmission.CurrentGear"@en .
-
-vsso:TransmissionDriveType a owl:Class ;
-    rdfs:label "TransmissionDriveType"@en ;
-    rdfs:comment "Drive type."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainTransmission ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Transmission.DriveType"@en .
-
-vsso:TransmissionGear a owl:Class ;
-    rdfs:label "TransmissionGear"@en ;
-    rdfs:comment "Current gear. 0=Neutral. -1=Reverse"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainTransmission ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Transmission.Gear"@en .
-
-vsso:TransmissionGearChangeMode a owl:Class ;
-    rdfs:label "TransmissionGearChangeMode"@en ;
-    rdfs:comment "Is the gearbox in automatic or manual (paddle) mode."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainTransmission ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Transmission.GearChangeMode"@en .
-
-vsso:TransmissionGearCount a owl:Class ;
-    rdfs:label "TransmissionGearCount"@en ;
-    rdfs:comment "Number of forward gears in the transmission. -1 = CVT."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainTransmission ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Transmission.GearCount"@en .
-
-vsso:TransmissionPerformanceMode a owl:Class ;
-    rdfs:label "TransmissionPerformanceMode"@en ;
-    rdfs:comment "Current gearbox performance mode."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainTransmission ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Transmission.PerformanceMode"@en .
-
-vsso:TransmissionSelectedGear a owl:Class ;
-    rdfs:label "TransmissionSelectedGear"@en ;
-    rdfs:comment "The selected gear. 0=Neutral, 1/2/..=Forward, -1/..=Reverse, 126=Park, 127=Drive"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainTransmission ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Transmission.SelectedGear"@en .
-
-vsso:TransmissionSpeed a owl:Class ;
-    rdfs:label "TransmissionSpeed"@en ;
-    rdfs:comment "Vehicle speed, as sensed by the gearbox."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainTransmission ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Transmission.Speed"@en .
-
-vsso:TransmissionTemperature a owl:Class ;
-    rdfs:label "TransmissionTemperature"@en ;
-    rdfs:comment "The current gearbox temperature"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainTransmission ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Transmission.Temperature"@en .
-
-vsso:TransmissionTravelledDistance a owl:Class ;
-    rdfs:label "TransmissionTravelledDistance"@en ;
-    rdfs:comment "Odometer reading, total distance travelled during the lifetime of the transmission."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainTransmission ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Transmission.TravelledDistance"@en .
-
-vsso:TransmissionType a owl:Class ;
-    rdfs:label "TransmissionType"@en ;
-    rdfs:comment "Transmission type."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainTransmission ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Powertrain.Transmission.Type"@en .
-
-vsso:TravelledDistance a owl:Class ;
-    rdfs:label "TravelledDistance"@en ;
-    rdfs:comment "Odometer reading, total distance travelled during the lifetime of the vehicle."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.TravelledDistance"@en .
-
-vsso:TripMeterReading a owl:Class ;
-    rdfs:label "TripMeterReading"@en ;
-    rdfs:comment "Current trip meter reading"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.TripMeterReading"@en .
-
-vsso:TrunkIsLocked a owl:Class ;
-    rdfs:label "TrunkIsLocked"@en ;
-    rdfs:comment "Is trunk locked or unlocked. True = Locked. False = Unlocked."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BodyTrunk ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Body.Trunk.IsLocked"@en .
-
-vsso:TrunkIsOpen a owl:Class ;
-    rdfs:label "TrunkIsOpen"@en ;
-    rdfs:comment "Trunk open or closed. True = Open. False = Closed"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BodyTrunk ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Body.Trunk.IsOpen"@en .
-
-vsso:Vehicle rdfs:label "Vehicle"@en ;
-    rdfs:comment "High-level vehicle data."@en ;
-    skos:altLabel "Vehicle"@en .
-
-vsso:VehicleIdentificationACRISSCode a owl:Class ;
-    rdfs:label "VehicleIdentificationACRISSCode"@en ;
-    rdfs:comment "The ACRISS Car Classification Code is a code used by many car rental companies."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VehicleIdentification ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.VehicleIdentification.ACRISSCode"@en .
-
-vsso:VehicleIdentificationBrand a owl:Class ;
-    rdfs:label "VehicleIdentificationBrand"@en ;
-    rdfs:comment "Vehicle brand or manufacturer"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VehicleIdentification ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.VehicleIdentification.Brand"@en .
-
-vsso:VehicleIdentificationModel a owl:Class ;
-    rdfs:label "VehicleIdentificationModel"@en ;
-    rdfs:comment "Vehicle model"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VehicleIdentification ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.VehicleIdentification.Model"@en .
-
-vsso:VehicleIdentificationVIN a owl:Class ;
-    rdfs:label "VehicleIdentificationVIN"@en ;
-    rdfs:comment "17-character Vehicle Identification Number (VIN) as defined by ISO 3779"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VehicleIdentification ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.VehicleIdentification.VIN"@en .
-
-vsso:VehicleIdentificationWMI a owl:Class ;
-    rdfs:label "VehicleIdentificationWMI"@en ;
-    rdfs:comment "3-character World Manufacturer Identification (WMI) as defined by ISO 3780"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VehicleIdentification ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.VehicleIdentification.WMI"@en .
-
-vsso:VehicleIdentificationYear a owl:Class ;
-    rdfs:label "VehicleIdentificationYear"@en ;
-    rdfs:comment "Model year of the vehicle"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VehicleIdentification ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.VehicleIdentification.Year"@en .
-
-vsso:VehicleIdentificationbodyType a owl:Class ;
-    rdfs:label "VehicleIdentificationbodyType"@en ;
-    rdfs:comment "Indicates the design and body style of the vehicle (e.g. station wagon, hatchback, etc.)."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VehicleIdentification ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.VehicleIdentification.bodyType"@en .
-
-vsso:VehicleIdentificationdateVehicleFirstRegistered a owl:Class ;
-    rdfs:label "VehicleIdentificationdateVehicleFirstRegistered"@en ;
-    rdfs:comment "The date of the first registration of the vehicle with the respective public authorities."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VehicleIdentification ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.VehicleIdentification.dateVehicleFirstRegistered"@en .
-
-vsso:VehicleIdentificationknownVehicleDamages a owl:Class ;
-    rdfs:label "VehicleIdentificationknownVehicleDamages"@en ;
-    rdfs:comment "A textual description of known damages, both repaired and unrepaired."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VehicleIdentification ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.VehicleIdentification.knownVehicleDamages"@en .
-
-vsso:VehicleIdentificationmeetsEmissionStandard a owl:Class ;
-    rdfs:label "VehicleIdentificationmeetsEmissionStandard"@en ;
-    rdfs:comment "Indicates that the vehicle meets the respective emission standard."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VehicleIdentification ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.VehicleIdentification.meetsEmissionStandard"@en .
-
-vsso:VehicleIdentificationproductionDate a owl:Class ;
-    rdfs:label "VehicleIdentificationproductionDate"@en ;
-    rdfs:comment "The date of production of the item, e.g. vehicle."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VehicleIdentification ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.VehicleIdentification.productionDate"@en .
-
-vsso:VehicleIdentificationpurchaseDate a owl:Class ;
-    rdfs:label "VehicleIdentificationpurchaseDate"@en ;
-    rdfs:comment "The date the item e.g. vehicle was purchased by the current owner."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VehicleIdentification ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.VehicleIdentification.purchaseDate"@en .
-
-vsso:VehicleIdentificationvehicleConfiguration a owl:Class ;
-    rdfs:label "VehicleIdentificationvehicleConfiguration"@en ;
-    rdfs:comment "A short text indicating the configuration of the vehicle, e.g. '5dr hatchback ST 2.5 MT 225 hp' or 'limited edition'."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VehicleIdentification ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.VehicleIdentification.vehicleConfiguration"@en .
-
-vsso:VehicleIdentificationvehicleModelDate a owl:Class ;
-    rdfs:label "VehicleIdentificationvehicleModelDate"@en ;
-    rdfs:comment "The release date of a vehicle model (often used to differentiate versions of the same make and model)."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VehicleIdentification ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.VehicleIdentification.vehicleModelDate"@en .
-
-vsso:VehicleIdentificationvehicleSeatingCapacity a owl:Class ;
-    rdfs:label "VehicleIdentificationvehicleSeatingCapacity"@en ;
-    rdfs:comment "The number of passengers that can be seated in the vehicle, both in terms of the physical space available, and in terms of limitations set by law."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VehicleIdentification ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.VehicleIdentification.vehicleSeatingCapacity"@en .
-
-vsso:VehicleIdentificationvehicleSpecialUsage a owl:Class ;
-    rdfs:label "VehicleIdentificationvehicleSpecialUsage"@en ;
-    rdfs:comment "Indicates whether the vehicle has been used for special purposes, like commercial rental, driving school."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VehicleIdentification ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.VehicleIdentification.vehicleSpecialUsage"@en .
-
-vsso:VehicleIdentificationvehicleinteriorColor a owl:Class ;
-    rdfs:label "VehicleIdentificationvehicleinteriorColor"@en ;
-    rdfs:comment "The color or color combination of the interior of the vehicle."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VehicleIdentification ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.VehicleIdentification.vehicleinteriorColor"@en .
-
-vsso:VehicleIdentificationvehicleinteriorType a owl:Class ;
-    rdfs:label "VehicleIdentificationvehicleinteriorType"@en ;
-    rdfs:comment "The type or material of the interior of the vehicle (e.g. synthetic fabric, leather, wood, etc.)."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VehicleIdentification ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.VehicleIdentification.vehicleinteriorType"@en .
-
-vsso:VersionVSSLabel a owl:Class ;
-    rdfs:label "VersionVSSLabel"@en ;
-    rdfs:comment "Label to further describe the version"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VersionVSS ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.VersionVSS.Label"@en .
-
-vsso:VersionVSSMajor a owl:Class ;
-    rdfs:label "VersionVSSMajor"@en ;
-    rdfs:comment "Supported Version of VSS - Major version"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VersionVSS ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.VersionVSS.Major"@en .
-
-vsso:VersionVSSMinor a owl:Class ;
-    rdfs:label "VersionVSSMinor"@en ;
-    rdfs:comment "Supported Version of VSS - Minor version"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VersionVSS ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.VersionVSS.Minor"@en .
-
-vsso:VersionVSSPatch a owl:Class ;
-    rdfs:label "VersionVSSPatch"@en ;
-    rdfs:comment "Supported Version of VSS - Patch version"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VersionVSS ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.VersionVSS.Patch"@en .
-
-vsso:WasherFluidLevel a owl:Class ;
-    rdfs:label "WasherFluidLevel"@en ;
-    rdfs:comment "Washer fluid level as a percent. 0 = Empty. 100 = Full."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:WindshieldWasherFluid ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Body.Windshield.WasherFluid.Level"@en .
-
-vsso:WasherFluidLevelLow a owl:Class ;
-    rdfs:label "WasherFluidLevelLow"@en ;
-    rdfs:comment "Low level indication for washer fluid. True = Level Low. False = Level OK."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:WindshieldWasherFluid ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Body.Windshield.WasherFluid.LevelLow"@en .
-
-vsso:Width a owl:Class ;
-    rdfs:label "Width"@en ;
-    rdfs:comment "Overall vehicle width."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.Width"@en .
-
-vsso:WindowChildLock a owl:Class ;
-    rdfs:label "WindowChildLock"@en ;
-    rdfs:comment "Is window child lock engaged. True = Engaged. False = Disengaged."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:DoorWindow ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Door.Window.ChildLock"@en .
-
-vsso:WindowPosition a owl:Class ;
-    rdfs:label "WindowPosition"@en ;
-    rdfs:comment "Window position. 0 = Fully closed 100 = Fully opened."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:DoorWindow ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Door.Window.Position"@en .
-
-vsso:WindowSwitch a owl:Class ;
-    rdfs:label "WindowSwitch"@en ;
-    rdfs:comment "Switch controlling sliding action such as window, sunroof, or blind."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:DoorWindow ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Door.Window.Switch"@en .
-
-vsso:WindowisOpen a owl:Class ;
-    rdfs:label "WindowisOpen"@en ;
-    rdfs:comment "Is window open or closed"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:DoorWindow ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Cabin.Door.Window.isOpen"@en .
-
-vsso:WipingStatus a owl:Class ;
-    rdfs:label "WipingStatus"@en ;
-    rdfs:comment "Wiper status"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:WindshieldWiping ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:ActuatableVehicleProperty,
-        vsso-core:ObservableVehicleProperty ;
-    skos:altLabel "Vehicle.Body.Windshield.Wiping.Status"@en .
-
-vsso:accelerationTime a owl:Class ;
-    rdfs:label "accelerationTime"@en ;
-    rdfs:comment "The time needed to accelerate the vehicle from a given start velocity to a given target velocity."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.accelerationTime"@en .
-
-vsso:cargoVolume a owl:Class ;
-    rdfs:label "cargoVolume"@en ;
-    rdfs:comment "The available volume for cargo or luggage. For automobiles, this is usually the trunk volume."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.cargoVolume"@en .
-
-vsso:emissionsCO2 a owl:Class ;
-    rdfs:label "emissionsCO2"@en ;
-    rdfs:comment "The CO2 emissions."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
-    skos:altLabel "Vehicle.emissionsCO2"@en .
-
-vsso:BodyChargingPort a owl:Class ;
-    rdfs:label "BodyChargingPort"@en ;
-    rdfs:comment "Collects Information about the charging port"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Body ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Body.ChargingPort"@en .
-
-vsso:BodyHood a owl:Class ;
-    rdfs:label "BodyHood"@en ;
-    rdfs:comment "Hood status"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Body ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Body.Hood"@en .
-
-vsso:BodyHorn a owl:Class ;
-    rdfs:label "BodyHorn"@en ;
-    rdfs:comment "Horn signals"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Body ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Body.Horn"@en .
-
-vsso:BodyRaindetection a owl:Class ;
-    rdfs:label "BodyRaindetection"@en ;
-    rdfs:comment "Rainsensor signals"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Body ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Body.Raindetection"@en .
-
-vsso:CabinConvertible a owl:Class ;
-    rdfs:label "CabinConvertible"@en ;
-    rdfs:comment "Convertible roof"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Cabin ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Cabin.Convertible"@en .
-
-vsso:CabinRearviewMirror a owl:Class ;
-    rdfs:label "CabinRearviewMirror"@en ;
-    rdfs:comment "Rearview mirror"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Cabin ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Cabin.RearviewMirror"@en .
-
-vsso:ChassisAccelerator a owl:Class ;
-    rdfs:label "ChassisAccelerator"@en ;
-    rdfs:comment "Accelerator signals"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Chassis ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Chassis.Accelerator"@en .
-
-vsso:ChassisBrake a owl:Class ;
-    rdfs:label "ChassisBrake"@en ;
-    rdfs:comment "Brake system signals"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Chassis ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Chassis.Brake"@en .
-
-vsso:ChassisParkingBrake a owl:Class ;
-    rdfs:label "ChassisParkingBrake"@en ;
-    rdfs:comment "Parking brake signals"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Chassis ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Chassis.ParkingBrake"@en .
-
-vsso:ChassisTrailer a owl:Class ;
-    rdfs:label "ChassisTrailer"@en ;
-    rdfs:comment "Trailer signals"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Chassis ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Chassis.Trailer"@en .
-
-vsso:MirrorsHeating a owl:Class ;
-    rdfs:label "MirrorsHeating"@en ;
-    rdfs:comment "Mirror heater signals"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BodyMirrors ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Body.Mirrors.Heating"@en .
-
-vsso:SeatAirbag a owl:Class ;
-    rdfs:label "SeatAirbag"@en ;
-    rdfs:comment "Airbag signals"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinSeat ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Cabin.Seat.Airbag"@en .
-
-vsso:SeatHeadRestraint a owl:Class ;
-    rdfs:label "SeatHeadRestraint"@en ;
-    rdfs:comment "Head restraint settings"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinSeat ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Cabin.Seat.HeadRestraint"@en .
-
-vsso:SeatOccupant a owl:Class ;
-    rdfs:label "SeatOccupant"@en ;
-    rdfs:comment "Occupant data."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinSeat ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Cabin.Seat.Occupant"@en .
-
-vsso:SeatSideBolster a owl:Class ;
-    rdfs:label "SeatSideBolster"@en ;
-    rdfs:comment "Side bolster settings"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinSeat ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Cabin.Seat.SideBolster"@en .
-
-vsso:Trailer a owl:Class ;
-    rdfs:label "Trailer"@en ;
-    rdfs:comment "Trailer signals"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Trailer"@en .
-
-vsso:WindshieldHeating a owl:Class ;
-    rdfs:label "WindshieldHeating"@en ;
-    rdfs:comment "Windshield heater signals"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BodyWindshield ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Body.Windshield.Heating"@en .
-
-vsso:WindshieldWiping a owl:Class ;
-    rdfs:label "WindshieldWiping"@en ;
-    rdfs:comment "Windshield wiper signals"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BodyWindshield ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Body.Windshield.Wiping"@en .
-
-vsso:ADASObstacleDetection a owl:Class ;
-    rdfs:label "ADASObstacleDetection"@en ;
-    rdfs:comment "Signals form Obstacle Sensor System"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ADAS ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.ADAS.ObstacleDetection"@en .
-
-vsso:AxleWheel a owl:Class ;
-    rdfs:label "AxleWheel"@en ;
-    rdfs:comment "Wheel signals for axle"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ChassisAxle ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Chassis.Axle.Wheel"@en .
-
-vsso:BodyTrunk a owl:Class ;
-    rdfs:label "BodyTrunk"@en ;
-    rdfs:comment "Trunk status"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Body ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Body.Trunk"@en .
-
-vsso:CabinRearShade a owl:Class ;
-    rdfs:label "CabinRearShade"@en ;
-    rdfs:comment "Rear window shade."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Cabin ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Cabin.RearShade"@en .
-
-vsso:CatalystBank1 a owl:Class ;
-    rdfs:label "CatalystBank1"@en ;
-    rdfs:comment "Catalyst bank 1 signals"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBDCatalyst ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.OBD.Catalyst.Bank1"@en .
-
-vsso:CatalystBank2 a owl:Class ;
-    rdfs:label "CatalystBank2"@en ;
-    rdfs:comment "Catalyst bank 2 signals"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBDCatalyst ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.OBD.Catalyst.Bank2"@en .
+    skos:definition "The time needed to complete the current charging process to the set charge limit. 0 if charging is complete, negative number if no charging process is active."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Charging.TimeToComplete"@en .
 
 vsso:ChargingTimer a owl:Class ;
     rdfs:label "ChargingTimer"@en ;
-    rdfs:comment "Properties related to timing of battery charging sessions."@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:BatteryCharging ;
             owl:onProperty vsso-core:partOf ],
         vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Powertrain.Battery.Charging.Timer"@en .
+    skos:definition "Properties related to timing of battery charging sessions."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Charging.Timer"@en .
+
+vsso:ChassisAccelerator a owl:Class ;
+    rdfs:label "ChassisAccelerator"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:Chassis ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Accelerator signals"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.Accelerator"@en .
+
+vsso:ChassisAxleCount a owl:Class ;
+    rdfs:label "ChassisAxleCount"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:Chassis ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Number of axles on the vehicle"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.AxleCount"@en .
+
+vsso:ChassisBrake a owl:Class ;
+    rdfs:label "ChassisBrake"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:Chassis ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Brake system signals"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.Brake"@en .
+
+vsso:ChassisCurbWeight a owl:Class ;
+    rdfs:label "ChassisCurbWeight"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:Chassis ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Vehicle curb weight, in kg, including all liquids and full tank of fuel, but no cargo or passengers."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.CurbWeight"@en .
+
+vsso:ChassisGrossWeight a owl:Class ;
+    rdfs:label "ChassisGrossWeight"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:Chassis ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Curb weight of vehicle, including all liquids and full tank of fuel and full load of cargo and passengers."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.GrossWeight"@en .
+
+vsso:ChassisHeight a owl:Class ;
+    rdfs:label "ChassisHeight"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:Chassis ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Overall vehicle height, in mm."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.Height"@en .
+
+vsso:ChassisLength a owl:Class ;
+    rdfs:label "ChassisLength"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:Chassis ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Overall vehicle length, in mm."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.Length"@en .
+
+vsso:ChassisParkingBrake a owl:Class ;
+    rdfs:label "ChassisParkingBrake"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:Chassis ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Parking brake signals"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.ParkingBrake"@en .
+
+vsso:ChassisTowWeight a owl:Class ;
+    rdfs:label "ChassisTowWeight"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:Chassis ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Maximum weight, in kilos, of trailer."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.TowWeight"@en .
+
+vsso:ChassisTrack a owl:Class ;
+    rdfs:label "ChassisTrack"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:Chassis ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Overall wheel tracking, in mm."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.Track"@en .
+
+vsso:ChassisTrailer a owl:Class ;
+    rdfs:label "ChassisTrailer"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:Chassis ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Trailer signals"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.Trailer"@en .
+
+vsso:ChassisTrailerConnected a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "ChassisTrailerConnected"@en ;
+    skos:definition "Signal indicating if trailer is connected or not."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.Trailer.Connected"@en .
+
+vsso:ChassisWheelbase a owl:Class ;
+    rdfs:label "ChassisWheelbase"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:Chassis ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Overall wheel base, in mm."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.Wheelbase"@en .
+
+vsso:ChassisWidth a owl:Class ;
+    rdfs:label "ChassisWidth"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:Chassis ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Overall vehicle width, in mm."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.Width"@en .
+
+vsso:CombustionEngineAspirationType a owl:Class ;
+    rdfs:label "CombustionEngineAspirationType"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Type of aspiration (natural, turbocharger, supercharger etc)."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.AspirationType"@en .
+
+vsso:CombustionEngineBore a owl:Class ;
+    rdfs:label "CombustionEngineBore"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Bore in millimetres."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.Bore"@en .
+
+vsso:CombustionEngineCompressionRatio a owl:Class ;
+    rdfs:label "CombustionEngineCompressionRatio"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Engine compression ratio."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.CompressionRatio"@en .
+
+vsso:CombustionEngineConfiguration a owl:Class ;
+    rdfs:label "CombustionEngineConfiguration"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Engine configuration."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.Configuration"@en .
+
+vsso:CombustionEngineDieselParticulateFilter a owl:Class ;
+    rdfs:label "CombustionEngineDieselParticulateFilter"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Diesel Particulate Filter signals"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.DieselParticulateFilter"@en .
+
+vsso:CombustionEngineDisplacement a owl:Class ;
+    rdfs:label "CombustionEngineDisplacement"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Displacement in cubic centimetres."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.Displacement"@en .
+
+vsso:CombustionEngineEngine a owl:Class ;
+    rdfs:label "CombustionEngineEngine"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Engine signals"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.Engine"@en .
+
+vsso:CombustionEngineEngineCoolantCapacity a owl:Class ;
+    rdfs:label "CombustionEngineEngineCoolantCapacity"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Engine coolant capacity in liters."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.EngineCoolantCapacity"@en .
+
+vsso:CombustionEngineEngineOilCapacity a owl:Class ;
+    rdfs:label "CombustionEngineEngineOilCapacity"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Engine oil capacity in liters."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.EngineOilCapacity"@en .
+
+vsso:CombustionEngineEngineOilLevel a owl:Class ;
+    rdfs:label "CombustionEngineEngineOilLevel"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Vehicle oil level."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.EngineOilLevel"@en .
+
+vsso:CombustionEngineFuelType a owl:Class ;
+    rdfs:label "CombustionEngineFuelType"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Type of fuel that the engine runs on."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.FuelType"@en .
+
+vsso:CombustionEngineMaxPower a owl:Class ;
+    rdfs:label "CombustionEngineMaxPower"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Peak power, in kilowatts, that engine can generate."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.MaxPower"@en .
+
+vsso:CombustionEngineMaxTorque a owl:Class ;
+    rdfs:label "CombustionEngineMaxTorque"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Peak power, in newton meter, that the engine can generate."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.MaxTorque"@en .
+
+vsso:CombustionEngineNumberOfCylinders a owl:Class ;
+    rdfs:label "CombustionEngineNumberOfCylinders"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Number of cylinders."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.NumberOfCylinders"@en .
+
+vsso:CombustionEngineNumberOfValvesPerCylinder a owl:Class ;
+    rdfs:label "CombustionEngineNumberOfValvesPerCylinder"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Number of valves per cylinder."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.NumberOfValvesPerCylinder"@en .
+
+vsso:CombustionEngineOilLifeRemaining a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "CombustionEngineOilLifeRemaining"@en ;
+    skos:definition "Remaining engine oil life in seconds. Negative values can be used to indicate that lifetime has been exceeded."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.OilLifeRemaining"@en .
+
+vsso:CombustionEngineStrokeLength a owl:Class ;
+    rdfs:label "CombustionEngineStrokeLength"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Stroke length in millimetres."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.StrokeLength"@en .
+
+vsso:ConvertibleStatus a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "ConvertibleStatus"@en ;
+    skos:definition "Roof status on convertible vehicles"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Convertible.Status"@en .
+
+vsso:CruiseControlError a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "CruiseControlError"@en ;
+    skos:definition "Indicates if cruise control system incurred and error condition. True = Error. False = NoError."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.ADAS.CruiseControl.Error"@en .
+
+vsso:CruiseControlIsActive a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "CruiseControlIsActive"@en ;
+    skos:definition "Indicates if cruise control system is enabled. True = Enabled. False = Disabled."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.ADAS.CruiseControl.IsActive"@en .
+
+vsso:CruiseControlSpeedSet a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "CruiseControlSpeedSet"@en ;
+    skos:definition "Set cruise control speed in kilometers per hour"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.ADAS.CruiseControl.SpeedSet"@en .
+
+vsso:CurbWeight a owl:Class ;
+    rdfs:label "CurbWeight"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso-core:Vehicle ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Vehicle curb weight, including all liquids and full tank of fuel, but no cargo or passengers."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.CurbWeight"@en .
+
+vsso:CurrentLocation a owl:Class ;
+    rdfs:label "CurrentLocation"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso-core:Vehicle ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "The current latitude and longitude of the vehicle."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.CurrentLocation"@en .
+
+vsso:CurrentLocationAccuracy a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "CurrentLocationAccuracy"@en ;
+    skos:definition "Accuracy level of the latitude and longitude coordinates."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.CurrentLocation.Accuracy"@en .
+
+vsso:CurrentLocationAltitude a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "CurrentLocationAltitude"@en ;
+    skos:definition "Current elevation of the position."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.CurrentLocation.Altitude"@en .
+
+vsso:CurrentLocationHeading a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "CurrentLocationHeading"@en ;
+    skos:definition "Current magnetic compass heading."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.CurrentLocation.Heading"@en .
+
+vsso:CurrentLocationLatitude a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "CurrentLocationLatitude"@en ;
+    skos:definition "Current latitude of vehicle."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.CurrentLocation.Latitude"@en .
+
+vsso:CurrentLocationLongitude a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "CurrentLocationLongitude"@en ;
+    skos:definition "Current longitude of vehicle."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.CurrentLocation.Longitude"@en .
+
+vsso:CurrentLocationSpeed a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "CurrentLocationSpeed"@en ;
+    skos:definition "Vehicle speed, as sensed by the GPS receiver."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Navigation.CurrentLocation.Speed"@en .
+
+vsso:CurrentOverallWeight a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "CurrentOverallWeight"@en ;
+    skos:definition "Current overall Vehicle weight. Including passengers, cargo and other load inside the car."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.CurrentOverallWeight"@en .
+
+vsso:CushionBackward a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "CushionBackward"@en ;
+    skos:definition "Seat cushion backward/shorten switch engaged (SingleSeat.Cushion.Length)"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Cushion.Backward"@en .
+
+vsso:CushionDown a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "CushionDown"@en ;
+    skos:definition "Seat cushion down switch engaged (SingleSeat.Cushion.Height)"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Cushion.Down"@en .
+
+vsso:CushionForward a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "CushionForward"@en ;
+    skos:definition "Seat cushion forward/lengthen switch engaged (SingleSeat.Cushion.Length)"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Cushion.Forward"@en .
+
+vsso:CushionHeight a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "CushionHeight"@en ;
+    skos:definition "Height of the seat cushion (leg support), relative to seat. 0 = Lowermost. 500 = Uppermost."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Cushion.Height"@en .
+
+vsso:CushionLength a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "CushionLength"@en ;
+    skos:definition "Forward length of cushion (leg support), relative to seat. 0 = Rearmost. 500 = Forwardmost."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Cushion.Length"@en .
+
+vsso:CushionUp a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "CushionUp"@en ;
+    skos:definition "Seat cushion up switch engaged (SingleSeat.Cushion.Height)"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Cushion.Up"@en .
+
+vsso:DestinationSetLatitude a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "DestinationSetLatitude"@en ;
+    skos:definition "Latitude of destination"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Navigation.DestinationSet.Latitude"@en .
+
+vsso:DestinationSetLongitude a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "DestinationSetLongitude"@en ;
+    skos:definition "Longitude of destination"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Navigation.DestinationSet.Longitude"@en .
+
+vsso:DieselParticulateFilterDeltaPressure a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "DieselParticulateFilterDeltaPressure"@en ;
+    skos:definition "Delta Pressure of Diesel Particulate Filter."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.DieselParticulateFilter.DeltaPressure"@en .
+
+vsso:DieselParticulateFilterInletTemperature a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "DieselParticulateFilterInletTemperature"@en ;
+    skos:definition "Inlet temperature of Diesel Particulate Filter."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.DieselParticulateFilter.InletTemperature"@en .
+
+vsso:DieselParticulateFilterOutletTemperature a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "DieselParticulateFilterOutletTemperature"@en ;
+    skos:definition "Outlet temperature of Diesel Particulate Filter."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.DieselParticulateFilter.OutletTemperature"@en .
+
+vsso:DoorIsChildLockActive a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "DoorIsChildLockActive"@en ;
+    skos:definition "Is door child lock engaged. True = Engaged. False = Disengaged."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Door.IsChildLockActive"@en .
+
+vsso:DoorIsLocked a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "DoorIsLocked"@en ;
+    skos:definition "Is door locked or unlocked. True = Locked. False = Unlocked."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Door.IsLocked"@en .
+
+vsso:DoorIsOpen a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "DoorIsOpen"@en ;
+    skos:definition "Is door open or closed"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Door.IsOpen"@en .
 
 vsso:DoorShade a owl:Class ;
     rdfs:label "DoorShade"@en ;
-    rdfs:comment "Side window shade"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:CabinDoor ;
             owl:onProperty vsso-core:partOf ],
         vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Cabin.Door.Shade"@en .
+    skos:definition "Side window shade"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Door.Shade"@en .
+
+vsso:DoorShadePosition a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "DoorShadePosition"@en ;
+    skos:definition "Position of window blind. 0 = Fully retracted. 100 = Fully deployed."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Door.Shade.Position"@en .
+
+vsso:DoorShadeSwitch a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "DoorShadeSwitch"@en ;
+    skos:definition "Switch controlling sliding action such as window, sunroof, or blind."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Door.Shade.Switch"@en .
+
+vsso:DoorWindow a owl:Class ;
+    rdfs:label "DoorWindow"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:CabinDoor ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Door window status"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Door.Window"@en .
+
+vsso:DriveCycleStatusDTCCount a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "DriveCycleStatusDTCCount"@en ;
+    skos:definition "Number of sensor Trouble Codes (DTC)"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.DriveCycleStatus.DTCCount"@en .
+
+vsso:DriveCycleStatusIgnitionType a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "DriveCycleStatusIgnitionType"@en ;
+    skos:definition "Type of the ignition for ICE - spark = spark plug ignition, compression = self-igniting (Diesel engines)"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.DriveCycleStatus.IgnitionType"@en .
+
+vsso:DriveCycleStatusMIL a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "DriveCycleStatusMIL"@en ;
+    skos:definition "Malfunction Indicator Light (MIL) - False = Off, True = On"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.DriveCycleStatus.MIL"@en .
+
+vsso:DriveTime a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "DriveTime"@en ;
+    skos:definition "Accumulated drive time in seconds."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.DriveTime"@en .
+
+vsso:DriverAttentiveProbability a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "DriverAttentiveProbability"@en ;
+    skos:definition "Probability of attentiveness of the driver."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Driver.AttentiveProbability"@en .
+
+vsso:DriverDistractionLevel a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "DriverDistractionLevel"@en ;
+    skos:definition "Distraction level of the driver will be the level how much the driver is distracted, by multiple factors. E.g. Driving situation, acustical or optical signales inside the cockpit, phone calls"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Driver.DistractionLevel"@en .
+
+vsso:DriverEyesOnRoad a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "DriverEyesOnRoad"@en ;
+    skos:definition "Has driver the eyes on road or not?"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Driver.EyesOnRoad"@en .
+
+vsso:DriverFatigueLevel a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "DriverFatigueLevel"@en ;
+    skos:definition "Fatigueness level of driver. Evaluated by multiple factors like trip time, behaviour of steering, eye status."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Driver.FatigueLevel"@en .
+
+vsso:DriverHeartRate a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "DriverHeartRate"@en ;
+    skos:definition "Heart rate of the driver."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Driver.HeartRate"@en .
 
 vsso:DriverIdentifier a owl:Class ;
     rdfs:label "DriverIdentifier"@en ;
-    rdfs:comment "Identifier attributes based on OAuth 2.0."@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:Driver ;
             owl:onProperty vsso-core:partOf ],
         vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Driver.Identifier"@en .
+    skos:definition "Identifier attributes based on OAuth 2.0."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Driver.Identifier"@en .
 
-vsso:InfotainmentNavigation a owl:Class ;
-    rdfs:label "InfotainmentNavigation"@en ;
-    rdfs:comment "All navigation actions"@en ;
+vsso:DriverIdentifierIssuer a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "DriverIdentifierIssuer"@en ;
+    skos:definition "Unique Issuer for the authentification of the occupant. E.g. https://accounts.funcorp.com"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Driver.Identifier.Issuer"@en .
+
+vsso:DriverIdentifierSubject a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "DriverIdentifierSubject"@en ;
+    skos:definition "Subject for the authentification of the occupant. E.g. UserID 7331677"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Driver.Identifier.Subject"@en .
+
+vsso:ESCError a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "ESCError"@en ;
+    skos:definition "Indicates if ESC incurred an error condition. True = Error. False = No Error."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.ADAS.ESC.Error"@en .
+
+vsso:ESCIsActive a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "ESCIsActive"@en ;
+    skos:definition "Indicates if ECS is enabled. True = Enabled. False = Disabled."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.ADAS.ESC.IsActive"@en .
+
+vsso:ESCIsEngaged a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "ESCIsEngaged"@en ;
+    skos:definition "Indicates if ESC is currently regulating vehicle stability. True = Engaged. False = Not Engaged."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.ADAS.ESC.IsEngaged"@en .
+
+vsso:ElectricMotorMaxPower a owl:Class ;
+    rdfs:label "ElectricMotorMaxPower"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:PowertrainElectricMotor ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Peak power, in kilowatts, that motor(s) can generate."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.ElectricMotor.MaxPower"@en .
+
+vsso:ElectricMotorMaxRegenPower a owl:Class ;
+    rdfs:label "ElectricMotorMaxRegenPower"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:PowertrainElectricMotor ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Peak regen/brake power, in kilowatts, that motor(s) can generate."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.ElectricMotor.MaxRegenPower"@en .
+
+vsso:ElectricMotorMaxRegenTorque a owl:Class ;
+    rdfs:label "ElectricMotorMaxRegenTorque"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:PowertrainElectricMotor ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Peak regen/brake torque, in newton meter, that the motor(s) can generate."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.ElectricMotor.MaxRegenTorque"@en .
+
+vsso:ElectricMotorMaxTorque a owl:Class ;
+    rdfs:label "ElectricMotorMaxTorque"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:PowertrainElectricMotor ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Peak power, in newton meter, that the motor(s) can generate."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.ElectricMotor.MaxTorque"@en .
+
+vsso:ElectricMotorMotor a owl:Class ;
+    rdfs:label "ElectricMotorMotor"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:PowertrainElectricMotor ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "motor signals"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.ElectricMotor.Motor"@en .
+
+vsso:EngineECT a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "EngineECT"@en ;
+    skos:definition "Engine coolant temperature."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.Engine.ECT"@en .
+
+vsso:EngineEOP a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "EngineEOP"@en ;
+    skos:definition "Engine oil pressure."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.Engine.EOP"@en .
+
+vsso:EngineEOT a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "EngineEOT"@en ;
+    skos:definition "Engine oil temperature."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.Engine.EOT"@en .
+
+vsso:EngineMAF a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "EngineMAF"@en ;
+    skos:definition "Grams of air drawn into engine per second."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.Engine.MAF"@en .
+
+vsso:EngineMAP a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "EngineMAP"@en ;
+    skos:definition "Manifold air pressure possibly boosted using forced induction."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.Engine.MAP"@en .
+
+vsso:EnginePower a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "EnginePower"@en ;
+    skos:definition "Current engine power output."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.Engine.Power"@en .
+
+vsso:EngineSpeed a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "EngineSpeed"@en ;
+    skos:definition "Engine speed measured as rotations per minute."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.Engine.Speed"@en .
+
+vsso:EngineTPS a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "EngineTPS"@en ;
+    skos:definition "Current throttle position."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.Engine.TPS"@en .
+
+vsso:EngineTorque a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "EngineTorque"@en ;
+    skos:definition "Current engine torque."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.Engine.Torque"@en .
+
+vsso:FuelSystemAverageConsumption a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "FuelSystemAverageConsumption"@en ;
+    skos:definition "Average consumption in liters per 100 km."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.FuelSystem.AverageConsumption"@en .
+
+vsso:FuelSystemConsumptionSinceStart a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "FuelSystemConsumptionSinceStart"@en ;
+    skos:definition "Fuel amount in liters consumed since start of current trip."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.FuelSystem.ConsumptionSinceStart"@en .
+
+vsso:FuelSystemEngineStopStartEnabled a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "FuelSystemEngineStopStartEnabled"@en ;
+    skos:definition "Indicates whether eco start stop is currently enabled"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.FuelSystem.EngineStopStartEnabled"@en .
+
+vsso:FuelSystemFuelType a owl:Class ;
+    rdfs:label "FuelSystemFuelType"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:PowertrainFuelSystem ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Defines the fuel type of the vehicle"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.FuelSystem.FuelType"@en .
+
+vsso:FuelSystemHybridType a owl:Class ;
+    rdfs:label "FuelSystemHybridType"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:PowertrainFuelSystem ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Defines the hybrid type of the vehicle"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.FuelSystem.HybridType"@en .
+
+vsso:FuelSystemInstantConsumption a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "FuelSystemInstantConsumption"@en ;
+    skos:definition "Current consumption in liters per 100 km."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.FuelSystem.InstantConsumption"@en .
+
+vsso:FuelSystemLevel a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "FuelSystemLevel"@en ;
+    skos:definition "Level in fuel tank as percent of capacity. 0 = empty. 100 = full."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.FuelSystem.Level"@en .
+
+vsso:FuelSystemLowFuelLevel a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "FuelSystemLowFuelLevel"@en ;
+    skos:definition "Indicates that the fuel level is low (e.g. <50km range)"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.FuelSystem.LowFuelLevel"@en .
+
+vsso:FuelSystemRange a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "FuelSystemRange"@en ;
+    skos:definition "Remaining range in meters using only liquid fuel."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.FuelSystem.Range"@en .
+
+vsso:FuelSystemTankCapacity a owl:Class ;
+    rdfs:label "FuelSystemTankCapacity"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:PowertrainFuelSystem ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Capacity of the fuel tank in liters"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.FuelSystem.TankCapacity"@en .
+
+vsso:FuelSystemTimeSinceStart a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "FuelSystemTimeSinceStart"@en ;
+    skos:definition "Time in seconds elapsed since start of current trip."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.FuelSystem.TimeSinceStart"@en .
+
+vsso:GrossWeight a owl:Class ;
+    rdfs:label "GrossWeight"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso-core:Vehicle ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Curb weight of vehicle, including all liquids and full tank of fuel and full load of cargo and passengers."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.GrossWeight"@en .
+
+vsso:HMICurrentLanguage a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "HMICurrentLanguage"@en ;
+    skos:definition "ISO 639-1 standard language code for the current HMI"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.HMI.CurrentLanguage"@en .
+
+vsso:HMIDateFormat a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "HMIDateFormat"@en ;
+    skos:definition "Date format used in the current HMI"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.HMI.DateFormat"@en .
+
+vsso:HMIDayNightMode a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "HMIDayNightMode"@en ;
+    skos:definition "Current display theme"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.HMI.DayNightMode"@en .
+
+vsso:HMIDistanceUnit a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "HMIDistanceUnit"@en ;
+    skos:definition "Distance unit used in the current HMI"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.HMI.DistanceUnit"@en .
+
+vsso:HMIEVEconomyUnits a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "HMIEVEconomyUnits"@en ;
+    skos:definition "EV fuel economy unit used in the current HMI"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.HMI.EVEconomyUnits"@en .
+
+vsso:HMIFuelEconomyUnits a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "HMIFuelEconomyUnits"@en ;
+    skos:definition "Fuel economy unit used in the current HMI"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.HMI.FuelEconomyUnits"@en .
+
+vsso:HMITemperatureUnit a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "HMITemperatureUnit"@en ;
+    skos:definition "Temperature unit used in the current HMI"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.HMI.TemperatureUnit"@en .
+
+vsso:HMITimeFormat a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "HMITimeFormat"@en ;
+    skos:definition "Time format used in the current HMI"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.HMI.TimeFormat"@en .
+
+vsso:HVACAmbientAirTemperature a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "HVACAmbientAirTemperature"@en ;
+    skos:definition "Ambient air temperature inside the vehicle."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.HVAC.AmbientAirTemperature"@en .
+
+vsso:HVACIsAirConditioningActive a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "HVACIsAirConditioningActive"@en ;
+    skos:definition "Is Air conditioning active."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.HVAC.IsAirConditioningActive"@en .
+
+vsso:HVACIsFrontDefrosterActive a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "HVACIsFrontDefrosterActive"@en ;
+    skos:definition "Is front defroster active."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.HVAC.IsFrontDefrosterActive"@en .
+
+vsso:HVACIsRearDefrosterActive a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "HVACIsRearDefrosterActive"@en ;
+    skos:definition "Is rear defroster active."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.HVAC.IsRearDefrosterActive"@en .
+
+vsso:HVACIsRecirculationActive a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "HVACIsRecirculationActive"@en ;
+    skos:definition "Is recirculation active."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.HVAC.IsRecirculationActive"@en .
+
+vsso:HVACStation a owl:Class ;
+    rdfs:label "HVACStation"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:CabinHVAC ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "HVAC for single station in the vehicle"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.HVAC.Station"@en .
+
+vsso:HeadRestraintDown a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "HeadRestraintDown"@en ;
+    skos:definition "Head restraint down switch engaged (SingleSeat.HeadRestraint.Height)"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.HeadRestraint.Down"@en .
+
+vsso:HeadRestraintHeight a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "HeadRestraintHeight"@en ;
+    skos:definition "Height of head restraint. 0 = Bottommost. 255 = Uppermost."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.HeadRestraint.Height"@en .
+
+vsso:HeadRestraintUp a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "HeadRestraintUp"@en ;
+    skos:definition "Head restraint up switch engaged (SingleSeat.HeadRestraint.Height)"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.HeadRestraint.Up"@en .
+
+vsso:HeatingStatus a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "HeatingStatus"@en ;
+    skos:definition "Windshield heater status. 0 - off, 1 - on"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Windshield.Heating.Status"@en .
+
+vsso:Height a owl:Class ;
+    rdfs:label "Height"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso-core:Vehicle ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Overall vehicle height."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Height"@en .
+
+vsso:HoodIsOpen a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "HoodIsOpen"@en ;
+    skos:definition "hood open or closed. True = Open. False = Closed"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Hood.IsOpen"@en .
+
+vsso:HornIsActive a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "HornIsActive"@en ;
+    skos:definition "Horn active or inactive. True = Active. False = Inactive."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Horn.IsActive"@en .
+
+vsso:IdentifierIssuer a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "IdentifierIssuer"@en ;
+    skos:definition "Unique Issuer for the authentification of the occupant. E.g. https://accounts.funcorp.com"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Occupant.Identifier.Issuer"@en .
+
+vsso:IdentifierSubject a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "IdentifierSubject"@en ;
+    skos:definition "Subject for the authentification of the occupant. E.g. UserID 7331677"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Occupant.Identifier.Subject"@en .
+
+vsso:IdleTime a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "IdleTime"@en ;
+    skos:definition "Accumulated idle time in seconds."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.IdleTime"@en .
+
+vsso:IgnitionOffTime a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "IgnitionOffTime"@en ;
+    skos:definition "Accumulated ignition off time in seconds."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.IgnitionOffTime"@en .
+
+vsso:IgnitionOn a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "IgnitionOn"@en ;
+    skos:definition "Indicates whether the vehicle ignition is on or off."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.IgnitionOn"@en .
+
+vsso:IgnitionOnTime a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "IgnitionOnTime"@en ;
+    skos:definition "Accumulated ignition on time in seconds."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.IgnitionOnTime"@en .
+
+vsso:InfotainmentHMI a owl:Class ;
+    rdfs:label "InfotainmentHMI"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:CabinInfotainment ;
             owl:onProperty vsso-core:partOf ],
         vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Cabin.Infotainment.Navigation"@en .
+    skos:definition "HMI related signals"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.HMI"@en .
 
-vsso:NavigationDestinationSet a owl:Class ;
-    rdfs:label "NavigationDestinationSet"@en ;
-    rdfs:comment "A navigation has been selected."@en ;
+vsso:IsMoving a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "IsMoving"@en ;
+    skos:definition "Indicates whether the vehicle is stationary or moving"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.IsMoving"@en .
+
+vsso:LaneDepartureDetectionError a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "LaneDepartureDetectionError"@en ;
+    skos:definition "Indicates if lane departure system incurred an error condition. True = Error. False = No Error."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.ADAS.LaneDepartureDetection.Error"@en .
+
+vsso:LaneDepartureDetectionIsActive a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "LaneDepartureDetectionIsActive"@en ;
+    skos:definition "Indicates if lane departure detection system is enabled. True = Enabled. False = Disabled."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.ADAS.LaneDepartureDetection.IsActive"@en .
+
+vsso:LaneDepartureDetectionWarning a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "LaneDepartureDetectionWarning"@en ;
+    skos:definition "Indicates if lane departure detection registered a lane departure"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.ADAS.LaneDepartureDetection.Warning"@en .
+
+vsso:Length a owl:Class ;
+    rdfs:label "Length"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso-core:Vehicle ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Overall vehicle length."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Length"@en .
+
+vsso:LightsAmbientLight a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "LightsAmbientLight"@en ;
+    skos:definition "How much ambient light is detected in cabin. 0 = No ambient light. 100 = Full brightness"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Lights.AmbientLight"@en .
+
+vsso:LightsIsBackupOn a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "LightsIsBackupOn"@en ;
+    skos:definition "Is backup (reverse) light on"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Lights.IsBackupOn"@en .
+
+vsso:LightsIsBrakeOn a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "LightsIsBrakeOn"@en ;
+    skos:definition "Is brake light on"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Lights.IsBrakeOn"@en .
+
+vsso:LightsIsDomeOn a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "LightsIsDomeOn"@en ;
+    skos:definition "Is central dome light light on"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Lights.IsDomeOn"@en .
+
+vsso:LightsIsFrontFogOn a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "LightsIsFrontFogOn"@en ;
+    skos:definition "Is front fog light on"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Lights.IsFrontFogOn"@en .
+
+vsso:LightsIsGloveBoxOn a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "LightsIsGloveBoxOn"@en ;
+    skos:definition "Is glove box light on"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Lights.IsGloveBoxOn"@en .
+
+vsso:LightsIsHazardOn a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "LightsIsHazardOn"@en ;
+    skos:definition "Are hazards on"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Lights.IsHazardOn"@en .
+
+vsso:LightsIsHighBeamOn a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "LightsIsHighBeamOn"@en ;
+    skos:definition "Is high beam on"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Lights.IsHighBeamOn"@en .
+
+vsso:LightsIsLeftIndicatorOn a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "LightsIsLeftIndicatorOn"@en ;
+    skos:definition "Is left indicator flashing"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Lights.IsLeftIndicatorOn"@en .
+
+vsso:LightsIsLowBeamOn a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "LightsIsLowBeamOn"@en ;
+    skos:definition "Is low beam on"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Lights.IsLowBeamOn"@en .
+
+vsso:LightsIsParkingOn a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "LightsIsParkingOn"@en ;
+    skos:definition "Is parking light on"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Lights.IsParkingOn"@en .
+
+vsso:LightsIsRearFogOn a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "LightsIsRearFogOn"@en ;
+    skos:definition "Is rear fog light on"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Lights.IsRearFogOn"@en .
+
+vsso:LightsIsRightIndicatorOn a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "LightsIsRightIndicatorOn"@en ;
+    skos:definition "Is right indicator flashing"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Lights.IsRightIndicatorOn"@en .
+
+vsso:LightsIsRunningOn a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "LightsIsRunningOn"@en ;
+    skos:definition "Are running lights on"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Lights.IsRunningOn"@en .
+
+vsso:LightsIsTrunkOn a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "LightsIsTrunkOn"@en ;
+    skos:definition "Is trunk light light on"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Lights.IsTrunkOn"@en .
+
+vsso:LightsLightIntensity a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "LightsLightIntensity"@en ;
+    skos:definition "Intensity of the interior lights. 0 = Off. 100 = Full brightness."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Lights.LightIntensity"@en .
+
+vsso:LightsSpotlight a owl:Class ;
+    rdfs:label "LightsSpotlight"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:CabinLights ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Spotlight for a specific area in the vehicle."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Lights.Spotlight"@en .
+
+vsso:LowVoltageSystemState a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "LowVoltageSystemState"@en ;
+    skos:definition "State of the supply voltage of the control units (usually 12V)."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.LowVoltageSystemState"@en .
+
+vsso:LumbarDeflate a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "LumbarDeflate"@en ;
+    skos:definition "Lumbar deflation switch engaged (SingleSeat.Lumbar.Inflation)"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Lumbar.Deflate"@en .
+
+vsso:LumbarDown a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "LumbarDown"@en ;
+    skos:definition "Lumbar down switch engaged (SingleSeat.Lumbar.Height)"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Lumbar.Down"@en .
+
+vsso:LumbarHeight a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "LumbarHeight"@en ;
+    skos:definition "Lumbar support position. 0 = Lowermost. 255 = Uppermost."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Lumbar.Height"@en .
+
+vsso:LumbarInflate a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "LumbarInflate"@en ;
+    skos:definition "Lumbar inflation switch engaged (SingleSeat.Lumbar.Inflation)"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Lumbar.Inflate"@en .
+
+vsso:LumbarInflation a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "LumbarInflation"@en ;
+    skos:definition "Lumbar support inflation. 0 = Fully deflated. 255 = Fully inflated."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Lumbar.Inflation"@en .
+
+vsso:LumbarUp a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "LumbarUp"@en ;
+    skos:definition "Lumbar up switch engaged (SingleSeat.Lumbar.Height)"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Lumbar.Up"@en .
+
+vsso:MassageDecrease a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "MassageDecrease"@en ;
+    skos:definition "Decrease massage level switch engaged (SingleSeat.Massage)"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Massage.Decrease"@en .
+
+vsso:MassageIncrease a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "MassageIncrease"@en ;
+    skos:definition "Increase massage level switch engaged (SingleSeat.Massage)"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Massage.Increase"@en .
+
+vsso:MaxTowBallWeight a owl:Class ;
+    rdfs:label "MaxTowBallWeight"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso-core:Vehicle ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Maximum vertical weight on the tow ball of a trailer."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.MaxTowBallWeight"@en .
+
+vsso:MaxTowWeight a owl:Class ;
+    rdfs:label "MaxTowWeight"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso-core:Vehicle ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Maximum weight of trailer."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.MaxTowWeight"@en .
+
+vsso:MediaAction a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "MediaAction"@en ;
+    skos:definition "Tells if the media was"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Media.Action"@en .
+
+vsso:MediaDeclinedURI a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "MediaDeclinedURI"@en ;
+    skos:definition "URI of suggested media that was declined"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Media.DeclinedURI"@en .
+
+vsso:MediaPlayed a owl:Class ;
+    rdfs:label "MediaPlayed"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:InfotainmentMedia ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Collection of signals updated in concert when a new media is played"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Media.Played"@en .
+
+vsso:MediaSelectedURI a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "MediaSelectedURI"@en ;
+    skos:definition "URI of suggested media that was selected"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Media.SelectedURI"@en .
+
+vsso:MediaVolume a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "MediaVolume"@en ;
+    skos:definition "Current Media Volume"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Media.Volume"@en .
+
+vsso:MirrorsHeating a owl:Class ;
+    rdfs:label "MirrorsHeating"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:BodyMirrors ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Mirror heater signals"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Mirrors.Heating"@en .
+
+vsso:MirrorsHeatingStatus a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "MirrorsHeatingStatus"@en ;
+    skos:definition "Mirror Heater on or off. True = Heater On. False = Heater Off."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Mirrors.Heating.Status"@en .
+
+vsso:MirrorsPan a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "MirrorsPan"@en ;
+    skos:definition "Mirror pan as a percent. 0 = Center Position. 100 = Fully Left Position. -100 = Fully Right Position."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Mirrors.Pan"@en .
+
+vsso:MirrorsTilt a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "MirrorsTilt"@en ;
+    skos:definition "Mirror tilt as a percent. 0 = Center Position. 100 = Fully Upward Position. -100 = Fully Downward Position."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Mirrors.Tilt"@en .
+
+vsso:MotorCoolantTemperature a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "MotorCoolantTemperature"@en ;
+    skos:definition "Motor coolant temperature (if applicable)."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.ElectricMotor.Motor.CoolantTemperature"@en .
+
+vsso:MotorPower a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "MotorPower"@en ;
+    skos:definition "Current motor power output. Negative values indicate regen mode."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.ElectricMotor.Motor.Power"@en .
+
+vsso:MotorRpm a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "MotorRpm"@en ;
+    skos:definition "Motor rotational speed measured as rotations per minute. Negative values indicate reverse driving mode."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.ElectricMotor.Motor.Rpm"@en .
+
+vsso:MotorTemperature a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "MotorTemperature"@en ;
+    skos:definition "Motor temperature."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.ElectricMotor.Motor.Temperature"@en .
+
+vsso:MotorTorque a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "MotorTorque"@en ;
+    skos:definition "Current motor torque. Negative values indicate regen mode."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.ElectricMotor.Motor.Torque"@en .
+
+vsso:NavigationCurrentLocation a owl:Class ;
+    rdfs:label "NavigationCurrentLocation"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:InfotainmentNavigation ;
             owl:onProperty vsso-core:partOf ],
         vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Cabin.Infotainment.Navigation.DestinationSet"@en .
+    skos:definition "The current latitude and longitude of the vehicle."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Navigation.CurrentLocation"@en .
 
-vsso:OBDCatalyst a owl:Class ;
-    rdfs:label "OBDCatalyst"@en ;
-    rdfs:comment "Catalyst signals"@en ;
+vsso:NavigationCurrentLocationAccuracy a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "NavigationCurrentLocationAccuracy"@en ;
+    skos:definition "Accuracy level of the latitude and longitude coordinates in meters."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Navigation.CurrentLocation.Accuracy"@en .
+
+vsso:NavigationCurrentLocationAltitude a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "NavigationCurrentLocationAltitude"@en ;
+    skos:definition "Current elevation of the position in meters."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Navigation.CurrentLocation.Altitude"@en .
+
+vsso:NavigationCurrentLocationHeading a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "NavigationCurrentLocationHeading"@en ;
+    skos:definition "Current magnetic compass heading, in degrees."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Navigation.CurrentLocation.Heading"@en .
+
+vsso:NavigationCurrentLocationLatitude a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "NavigationCurrentLocationLatitude"@en ;
+    skos:definition "Current latitude of vehicle, as reported by GPS."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Navigation.CurrentLocation.Latitude"@en .
+
+vsso:NavigationCurrentLocationLongitude a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "NavigationCurrentLocationLongitude"@en ;
+    skos:definition "Current longitude of vehicle, as reported by GPS."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Navigation.CurrentLocation.Longitude"@en .
+
+vsso:NavigationDestinationSet a owl:Class ;
+    rdfs:label "NavigationDestinationSet"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:InfotainmentNavigation ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "A navigation has been selected."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Navigation.DestinationSet"@en .
+
+vsso:O2ShortTermFuelTrim a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "O2ShortTermFuelTrim"@en ;
+    skos:definition "PID 1x (byte B) - Short term fuel trim"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.O2.ShortTermFuelTrim"@en .
+
+vsso:O2Voltage a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "O2Voltage"@en ;
+    skos:definition "PID 1x (byte A) - Sensor voltage"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.O2.Voltage"@en .
+
+vsso:O2WRCurrent a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "O2WRCurrent"@en ;
+    skos:definition "PID 3x (byte CD) - Current for wide range/band oxygen sensor"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.O2WR.Current"@en .
+
+vsso:O2WRLambda a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "O2WRLambda"@en ;
+    skos:definition "PID 2x (byte AB) and PID 3x (byte AB) - Lambda for wide range/band oxygen sensor"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.O2WR.Lambda"@en .
+
+vsso:O2WRVoltage a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "O2WRVoltage"@en ;
+    skos:definition "PID 2x (byte CD) - Voltage for wide range/band oxygen sensor"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.O2WR.Voltage"@en .
+
+vsso:OBDAbsoluteLoad a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDAbsoluteLoad"@en ;
+    skos:definition "PID 43 - Absolute load value"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.AbsoluteLoad"@en .
+
+vsso:OBDAcceleratorPositionD a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDAcceleratorPositionD"@en ;
+    skos:definition "PID 49 - Accelerator pedal position D"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.AcceleratorPositionD"@en .
+
+vsso:OBDAcceleratorPositionE a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDAcceleratorPositionE"@en ;
+    skos:definition "PID 4A - Accelerator pedal position E"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.AcceleratorPositionE"@en .
+
+vsso:OBDAcceleratorPositionF a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDAcceleratorPositionF"@en ;
+    skos:definition "PID 4B - Accelerator pedal position F"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.AcceleratorPositionF"@en .
+
+vsso:OBDAirStatus a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDAirStatus"@en ;
+    skos:definition "PID 12 - Secondary air status"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.AirStatus"@en .
+
+vsso:OBDAmbientAirTemperature a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDAmbientAirTemperature"@en ;
+    skos:definition "PID 46 - Ambient air temperature"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.AmbientAirTemperature"@en .
+
+vsso:OBDAuxInputStatus a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDAuxInputStatus"@en ;
+    skos:definition "PID 1E - Auxiliary input status (power take off)"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.AuxInputStatus"@en .
+
+vsso:OBDBarometricPressure a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDBarometricPressure"@en ;
+    skos:definition "PID 33 - Barometric pressure"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.BarometricPressure"@en .
+
+vsso:OBDCommandedEGR a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDCommandedEGR"@en ;
+    skos:definition "PID 2C - Commanded exhaust gas recirculation (EGR)"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.CommandedEGR"@en .
+
+vsso:OBDCommandedEVAP a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDCommandedEVAP"@en ;
+    skos:definition "PID 2E - Commanded evaporative purge (EVAP) valve"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.CommandedEVAP"@en .
+
+vsso:OBDCommandedEquivalenceRatio a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDCommandedEquivalenceRatio"@en ;
+    skos:definition "PID 44 - Commanded equivalence ratio"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.CommandedEquivalenceRatio"@en .
+
+vsso:OBDControlModuleVoltage a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDControlModuleVoltage"@en ;
+    skos:definition "PID 42 - Control module voltage"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.ControlModuleVoltage"@en .
+
+vsso:OBDCoolantTemperature a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDCoolantTemperature"@en ;
+    skos:definition "PID 05 - Coolant temperature"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.CoolantTemperature"@en .
+
+vsso:OBDDTCList a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDDTCList"@en ;
+    skos:definition "List of currently active DTCs formatted according OBD II (SAE-J2012DA_201812) standard ([P|C|B|U]XXXXX )"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.DTCList"@en .
+
+vsso:OBDDistanceSinceDTCClear a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDDistanceSinceDTCClear"@en ;
+    skos:definition "PID 31 - Distance traveled since codes cleared"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.DistanceSinceDTCClear"@en .
+
+vsso:OBDDistanceWithMIL a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDDistanceWithMIL"@en ;
+    skos:definition "PID 21 - Distance traveled with MIL on"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.DistanceWithMIL"@en .
+
+vsso:OBDDriveCycleStatus a owl:Class ;
+    rdfs:label "OBDDriveCycleStatus"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:OBD ;
             owl:onProperty vsso-core:partOf ],
         vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.OBD.Catalyst"@en .
+    skos:definition "PID 41 - OBD status for the current drive cycle"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.DriveCycleStatus"@en .
+
+vsso:OBDEGRError a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDEGRError"@en ;
+    skos:definition "PID 2D - Exhaust gas recirculation (EGR) error"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.EGRError"@en .
+
+vsso:OBDEVAPVaporPressure a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDEVAPVaporPressure"@en ;
+    skos:definition "PID 32 - Evaporative purge (EVAP) system pressure"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.EVAPVaporPressure"@en .
+
+vsso:OBDEVAPVaporPressureAbsolute a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDEVAPVaporPressureAbsolute"@en ;
+    skos:definition "PID 53 - Absolute evaporative purge (EVAP) system pressure"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.EVAPVaporPressureAbsolute"@en .
+
+vsso:OBDEVAPVaporPressureAlternate a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDEVAPVaporPressureAlternate"@en ;
+    skos:definition "PID 54 - Alternate evaporative purge (EVAP) system pressure"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.EVAPVaporPressureAlternate"@en .
+
+vsso:OBDEngineLoad a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDEngineLoad"@en ;
+    skos:definition "PID 04 - Engine load in percent - 0 = no load, 100 = full load"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.EngineLoad"@en .
+
+vsso:OBDEngineSpeed a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDEngineSpeed"@en ;
+    skos:definition "PID 0C - Engine speed measured as rotations per minute"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.EngineSpeed"@en .
+
+vsso:OBDEthanolPercent a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDEthanolPercent"@en ;
+    skos:definition "PID 52 - Percentage of ethanol in the fuel"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.EthanolPercent"@en .
+
+vsso:OBDFreezeDTC a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDFreezeDTC"@en ;
+    skos:definition "PID 02 - DTC that triggered the freeze frame"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.FreezeDTC"@en .
+
+vsso:OBDFuelInjectionTiming a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDFuelInjectionTiming"@en ;
+    skos:definition "PID 5D - Fuel injection timing"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.FuelInjectionTiming"@en .
+
+vsso:OBDFuelLevel a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDFuelLevel"@en ;
+    skos:definition "PID 2F - Fuel level in the fuel tank"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.FuelLevel"@en .
+
+vsso:OBDFuelPressure a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDFuelPressure"@en ;
+    skos:definition "PID 0A - Fuel pressure"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.FuelPressure"@en .
+
+vsso:OBDFuelRailPressureAbsolute a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDFuelRailPressureAbsolute"@en ;
+    skos:definition "PID 59 - Absolute fuel rail pressure"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.FuelRailPressureAbsolute"@en .
+
+vsso:OBDFuelRailPressureDirect a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDFuelRailPressureDirect"@en ;
+    skos:definition "PID 23 - Fuel rail pressure direct inject"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.FuelRailPressureDirect"@en .
+
+vsso:OBDFuelRailPressureVac a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDFuelRailPressureVac"@en ;
+    skos:definition "PID 22 - Fuel rail pressure relative to vacuum"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.FuelRailPressureVac"@en .
+
+vsso:OBDFuelRate a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDFuelRate"@en ;
+    skos:definition "PID 5E - Engine fuel rate"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.FuelRate"@en .
+
+vsso:OBDFuelStatus a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDFuelStatus"@en ;
+    skos:definition "PID 03 - Fuel status"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.FuelStatus"@en .
+
+vsso:OBDFuelType a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDFuelType"@en ;
+    skos:definition "PID 51 - Fuel type"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.FuelType"@en .
+
+vsso:OBDHybridBatteryRemaining a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDHybridBatteryRemaining"@en ;
+    skos:definition "PID 5B - Remaining life of hybrid battery"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.HybridBatteryRemaining"@en .
+
+vsso:OBDIntakeTemp a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDIntakeTemp"@en ;
+    skos:definition "PID 0F - Intake temperature"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.IntakeTemp"@en .
+
+vsso:OBDLongTermFuelTrim1 a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDLongTermFuelTrim1"@en ;
+    skos:definition "PID 07 - Long Term (learned) Fuel Trim - Bank 1 - negative percent leaner, positive percent richer"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.LongTermFuelTrim1"@en .
+
+vsso:OBDLongTermFuelTrim2 a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDLongTermFuelTrim2"@en ;
+    skos:definition "PID 09 - Long Term (learned) Fuel Trim - Bank 2 - negative percent leaner, positive percent richer"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.LongTermFuelTrim2"@en .
+
+vsso:OBDLongTermO2Trim1 a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDLongTermO2Trim1"@en ;
+    skos:definition "PID 56 (byte A) - Long term secondary O2 trim - Bank 1"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.LongTermO2Trim1"@en .
+
+vsso:OBDLongTermO2Trim2 a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDLongTermO2Trim2"@en ;
+    skos:definition "PID 58 (byte A) - Long term secondary O2 trim - Bank 2"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.LongTermO2Trim2"@en .
+
+vsso:OBDLongTermO2Trim3 a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDLongTermO2Trim3"@en ;
+    skos:definition "PID 56 (byte B) - Long term secondary O2 trim - Bank 3"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.LongTermO2Trim3"@en .
+
+vsso:OBDLongTermO2Trim4 a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDLongTermO2Trim4"@en ;
+    skos:definition "PID 58 (byte B) - Long term secondary O2 trim - Bank 4"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.LongTermO2Trim4"@en .
+
+vsso:OBDMAF a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDMAF"@en ;
+    skos:definition "PID 10 - Grams of air drawn into engine per second"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.MAF"@en .
+
+vsso:OBDMAP a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDMAP"@en ;
+    skos:definition "PID 0B - Intake manifold pressure"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.MAP"@en .
+
+vsso:OBDMaxMAF a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDMaxMAF"@en ;
+    skos:definition "PID 50 - Maximum flow for mass air flow sensor"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.MaxMAF"@en .
 
 vsso:OBDO2 a owl:Class ;
     rdfs:label "OBDO2"@en ;
-    rdfs:comment "Oxygen sensors (PID 14 - PID 1B)"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:OBD ;
             owl:onProperty vsso-core:partOf ],
         vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.OBD.O2"@en .
+    skos:definition "Oxygen sensors (PID 14 - PID 1B)"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.O2"@en .
+
+vsso:OBDO2WR a owl:Class ;
+    rdfs:label "OBDO2WR"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:OBD ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Wide range/band oxygen sensors (PID 24 - 2B and PID 34 - 3B)"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.O2WR"@en .
+
+vsso:OBDOBDStandards a owl:Class ;
+    rdfs:label "OBDOBDStandards"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:OBD ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "PID 1C - OBD standards this vehicle conforms to"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.OBDStandards"@en .
+
+vsso:OBDOilTemperature a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDOilTemperature"@en ;
+    skos:definition "PID 5C - Engine oil temperature"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.OilTemperature"@en .
+
+vsso:OBDOxygenSensorsIn2Banks a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDOxygenSensorsIn2Banks"@en ;
+    skos:definition "PID 13 - Presence of oxygen sensors in 2 banks. [A0..A3] == Bank 1, Sensors 1-4. [A4..A7] == Bank 2, Sensors 1-4"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.OxygenSensorsIn2Banks"@en .
+
+vsso:OBDOxygenSensorsIn4Banks a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDOxygenSensorsIn4Banks"@en ;
+    skos:definition "PID 1D - Presence of oxygen sensors in 4 banks. Similar to PID 13, but [A0..A7] == [B1S1, B1S2, B2S1, B2S2, B3S1, B3S2, B4S1, B4S2]"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.OxygenSensorsIn4Banks"@en .
+
+vsso:OBDPidsA a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDPidsA"@en ;
+    skos:definition "PID 00 - Bit array of the supported pids 01 to 20"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.PidsA"@en .
+
+vsso:OBDPidsB a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDPidsB"@en ;
+    skos:definition "PID 20 - Bit array of the supported pids 21 to 40"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.PidsB"@en .
+
+vsso:OBDPidsC a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDPidsC"@en ;
+    skos:definition "PID 40 - Bit array of the supported pids 41 to 60"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.PidsC"@en .
+
+vsso:OBDRelativeAcceleratorPosition a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDRelativeAcceleratorPosition"@en ;
+    skos:definition "PID 5A - Relative accelerator pedal position"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.RelativeAcceleratorPosition"@en .
+
+vsso:OBDRelativeThrottlePosition a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDRelativeThrottlePosition"@en ;
+    skos:definition "PID 45 - Relative throttle position"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.RelativeThrottlePosition"@en .
+
+vsso:OBDRunTime a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDRunTime"@en ;
+    skos:definition "PID 1F - Engine run time"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.RunTime"@en .
+
+vsso:OBDRunTimeMIL a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDRunTimeMIL"@en ;
+    skos:definition "PID 4D - Run time with MIL on"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.RunTimeMIL"@en .
+
+vsso:OBDShortTermFuelTrim1 a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDShortTermFuelTrim1"@en ;
+    skos:definition "PID 06 - Short Term (immediate) Fuel Trim - Bank 1 - negative percent leaner, positive percent richer"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.ShortTermFuelTrim1"@en .
+
+vsso:OBDShortTermFuelTrim2 a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDShortTermFuelTrim2"@en ;
+    skos:definition "PID 08 - Short Term (immediate) Fuel Trim - Bank 2 - negative percent leaner, positive percent richer"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.ShortTermFuelTrim2"@en .
+
+vsso:OBDShortTermO2Trim1 a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDShortTermO2Trim1"@en ;
+    skos:definition "PID 55 (byte A) - Short term secondary O2 trim - Bank 1"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.ShortTermO2Trim1"@en .
+
+vsso:OBDShortTermO2Trim2 a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDShortTermO2Trim2"@en ;
+    skos:definition "PID 57 (byte A) - Short term secondary O2 trim - Bank 2"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.ShortTermO2Trim2"@en .
+
+vsso:OBDShortTermO2Trim3 a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDShortTermO2Trim3"@en ;
+    skos:definition "PID 55 (byte B) - Short term secondary O2 trim - Bank 3"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.ShortTermO2Trim3"@en .
+
+vsso:OBDShortTermO2Trim4 a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDShortTermO2Trim4"@en ;
+    skos:definition "PID 57 (byte B) - Short term secondary O2 trim - Bank 4"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.ShortTermO2Trim4"@en .
+
+vsso:OBDSpeed a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDSpeed"@en ;
+    skos:definition "PID 0D - Vehicle speed"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.Speed"@en .
+
+vsso:OBDStatus a owl:Class ;
+    rdfs:label "OBDStatus"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:OBD ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "PID 01 - OBD status"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.Status"@en .
+
+vsso:OBDThrottleActuator a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDThrottleActuator"@en ;
+    skos:definition "PID 4C - Commanded throttle actuator"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.ThrottleActuator"@en .
+
+vsso:OBDThrottlePosition a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDThrottlePosition"@en ;
+    skos:definition "PID 11 - Throttle position - 0 = closed throttle, 100 = open throttle"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.ThrottlePosition"@en .
+
+vsso:OBDThrottlePositionB a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDThrottlePositionB"@en ;
+    skos:definition "PID 47 - Absolute throttle position B"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.ThrottlePositionB"@en .
+
+vsso:OBDThrottlePositionC a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDThrottlePositionC"@en ;
+    skos:definition "PID 48 - Absolute throttle position C"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.ThrottlePositionC"@en .
+
+vsso:OBDTimeSinceDTCCleared a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDTimeSinceDTCCleared"@en ;
+    skos:definition "PID 4E - Time since trouble codes cleared"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.TimeSinceDTCCleared"@en .
+
+vsso:OBDTimingAdvance a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDTimingAdvance"@en ;
+    skos:definition "PID 0E - Time advance"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.TimingAdvance"@en .
+
+vsso:OBDWarmupsSinceDTCClear a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "OBDWarmupsSinceDTCClear"@en ;
+    skos:definition "PID 30 - Number of warm-ups since codes cleared"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.WarmupsSinceDTCClear"@en .
+
+vsso:ObstacleDetectionError a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "ObstacleDetectionError"@en ;
+    skos:definition "Indicates if obstacle sensor system incurred an error condition. True = Error. False = No Error."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.ADAS.ObstacleDetection.Error"@en .
+
+vsso:ObstacleDetectionIsActive a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "ObstacleDetectionIsActive"@en ;
+    skos:definition "Indicates if obstacle sensor system is enabled. True = Enabled. False = Disabled."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.ADAS.ObstacleDetection.IsActive"@en .
 
 vsso:OccupantIdentifier a owl:Class ;
     rdfs:label "OccupantIdentifier"@en ;
-    rdfs:comment "Identifier attributes based on OAuth 2.0."@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:SeatOccupant ;
             owl:onProperty vsso-core:partOf ],
         vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Cabin.Seat.Occupant.Identifier"@en .
+    skos:definition "Identifier attributes based on OAuth 2.0."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Occupant.Identifier"@en .
+
+vsso:ParkingBrakeIsEngaged a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "ParkingBrakeIsEngaged"@en ;
+    skos:definition "Parking brake status. True = Parking Brake is Engaged. False = Parking Brake is not Engaged."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.ParkingBrake.IsEngaged"@en .
+
+vsso:PlayedAlbum a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "PlayedAlbum"@en ;
+    skos:definition "Name of album being played"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Media.Played.Album"@en .
+
+vsso:PlayedArtist a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "PlayedArtist"@en ;
+    skos:definition "Name of artist being played"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Media.Played.Artist"@en .
+
+vsso:PlayedSource a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "PlayedSource"@en ;
+    skos:definition "Media selected for playback"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Media.Played.Source"@en .
+
+vsso:PlayedTrack a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "PlayedTrack"@en ;
+    skos:definition "Name of track being played"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Media.Played.Track"@en .
+
+vsso:PlayedURI a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "PlayedURI"@en ;
+    skos:definition "User Resource associated with the media"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Media.Played.URI"@en .
+
+vsso:PowertrainAccumulatedBrakingEnergy a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "PowertrainAccumulatedBrakingEnergy"@en ;
+    skos:definition "The accumulated energy from regenerative braking over lifetime."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.AccumulatedBrakingEnergy"@en .
+
+vsso:PowertrainRange a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "PowertrainRange"@en ;
+    skos:definition "Remaining range in meters using all energy sources available in the vehicle."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Range"@en .
+
+vsso:Private a owl:Class ;
+    rdfs:label "Private"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso-core:Vehicle ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Uncontrolled branch where non-public signals can be defined."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Private"@en .
+
+vsso:Raindetectionintensity a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "Raindetectionintensity"@en ;
+    skos:definition "Rain intensity. 0 = Dry, No Rain. 100 = Covered."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Raindetection.intensity"@en .
+
+vsso:RearShadePosition a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "RearShadePosition"@en ;
+    skos:definition "Position of window blind. 0 = Fully retracted. 100 = Fully deployed."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.RearShade.Position"@en .
+
+vsso:RearShadeSwitch a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "RearShadeSwitch"@en ;
+    skos:definition "Switch controlling sliding action such as window, sunroof, or blind."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.RearShade.Switch"@en .
+
+vsso:RearviewMirrorDimmingLevel a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "RearviewMirrorDimmingLevel"@en ;
+    skos:definition "Dimming level of rearview mirror. 0 = undimmed. 100 = fully dimmed"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.RearviewMirror.DimmingLevel"@en .
+
+vsso:ReclineBackward a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "ReclineBackward"@en ;
+    skos:definition "Seatback recline backward switch engaged (SingleSeat.Recline)"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Recline.Backward"@en .
+
+vsso:ReclineForward a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "ReclineForward"@en ;
+    skos:definition "Seatback recline forward switch engaged (SingleSeat.Recline)"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Recline.Forward"@en .
+
+vsso:RoofLoad a owl:Class ;
+    rdfs:label "RoofLoad"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso-core:Vehicle ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "The permitted total weight of cargo and installations (e.g. a roof rack) on top of the vehicle."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.RoofLoad"@en .
+
+vsso:SeatAirbag a owl:Class ;
+    rdfs:label "SeatAirbag"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:CabinSeat ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Airbag signals"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Airbag"@en .
 
 vsso:SeatCushion a owl:Class ;
     rdfs:label "SeatCushion"@en ;
-    rdfs:comment "Cushion (leg support) signals."@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:CabinSeat ;
             owl:onProperty vsso-core:partOf ],
         vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Cabin.Seat.Cushion"@en .
+    skos:definition "Cushion (leg support) signals."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Cushion"@en .
+
+vsso:SeatHasPassenger a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "SeatHasPassenger"@en ;
+    skos:definition "Does the seat have a passenger in it."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.HasPassenger"@en .
+
+vsso:SeatHeadRestraint a owl:Class ;
+    rdfs:label "SeatHeadRestraint"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:CabinSeat ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Head restraint settings"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.HeadRestraint"@en .
+
+vsso:SeatHeating a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "SeatHeating"@en ;
+    skos:definition "Seat cooling / heating. 0 = off. -100 = max cold. +100 = max heat."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Heating"@en .
+
+vsso:SeatHeight a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "SeatHeight"@en ;
+    skos:definition "Seat vertical position. 0 = Lowermost. 1000 = Uppermost."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Height"@en .
+
+vsso:SeatIsBelted a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "SeatIsBelted"@en ;
+    skos:definition "Is the belt engaged."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.IsBelted"@en .
 
 vsso:SeatLumbar a owl:Class ;
     rdfs:label "SeatLumbar"@en ;
-    rdfs:comment "Lumbar signals"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:CabinSeat ;
             owl:onProperty vsso-core:partOf ],
         vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Cabin.Seat.Lumbar"@en .
+    skos:definition "Lumbar signals"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Lumbar"@en .
+
+vsso:SeatMassage a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "SeatMassage"@en ;
+    skos:definition "Seat massage level. 0 = off. 100 = max massage."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Massage"@en .
+
+vsso:SeatPosition a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "SeatPosition"@en ;
+    skos:definition "Seat horizontal position. 0 = Frontmost. 1000 = Rearmost."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Position"@en .
+
+vsso:SeatRecline a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "SeatRecline"@en ;
+    skos:definition "Recline level. -90 = Max forward recline. 90 max backward recline."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Recline"@en .
+
+vsso:SeatSideBolster a owl:Class ;
+    rdfs:label "SeatSideBolster"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:CabinSeat ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Side bolster settings"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.SideBolster"@en .
+
+vsso:Service a owl:Class ;
+    rdfs:label "Service"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso-core:Vehicle ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Service data."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Service"@en .
+
+vsso:ServiceDistanceToService a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "ServiceDistanceToService"@en ;
+    skos:definition "Remaining distance to service (of any kind). Negative values indicate service overdue."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Service.DistanceToService"@en .
+
+vsso:ServiceServiceDue a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "ServiceServiceDue"@en ;
+    skos:definition "Indicates if vehicle needs service (of any kind). True = Service needed now or in the near future. False = No known need for service."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Service.ServiceDue"@en .
+
+vsso:ServiceTimeToService a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "ServiceTimeToService"@en ;
+    skos:definition "Remaining time to service (of any kind). Negative values indicate service overdue."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Service.TimeToService"@en .
+
+vsso:ShadePosition a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "ShadePosition"@en ;
+    skos:definition "Position of window blind. 0 = Fully retracted. 100 = Fully deployed."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Sunroof.Shade.Position"@en .
+
+vsso:ShadeSwitch a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "ShadeSwitch"@en ;
+    skos:definition "Switch controlling sliding action such as window, sunroof, or blind."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Sunroof.Shade.Switch"@en .
+
+vsso:SideBolsterDeflate a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "SideBolsterDeflate"@en ;
+    skos:definition "Side bolster deflation switch engaged (SingleSeat.SideBolster.Inflation)"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.SideBolster.Deflate"@en .
+
+vsso:SideBolsterInflate a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "SideBolsterInflate"@en ;
+    skos:definition "Side bolster inflation switch engaged (SingleSeat.SideBolster.Inflation)"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.SideBolster.Inflate"@en .
+
+vsso:SideBolsterInflation a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "SideBolsterInflation"@en ;
+    skos:definition "Side bolster support inflation. 0 = Fully deflated. 255 = Fully inflated."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.SideBolster.Inflation"@en .
+
+vsso:Speed a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "Speed"@en ;
+    skos:definition "Vehicle speed"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Speed"@en .
+
+vsso:SpotlightIsLeftOn a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "SpotlightIsLeftOn"@en ;
+    skos:definition "Is light on the left side switched on"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Lights.Spotlight.IsLeftOn"@en .
+
+vsso:SpotlightIsRightOn a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "SpotlightIsRightOn"@en ;
+    skos:definition "Is light on the right side switched on"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Lights.Spotlight.IsRightOn"@en .
+
+vsso:SpotlightIsSharedOn a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "SpotlightIsSharedOn"@en ;
+    skos:definition "Is a shared light across a specific row on"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Lights.Spotlight.IsSharedOn"@en .
+
+vsso:StateOfChargeCurrent a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "StateOfChargeCurrent"@en ;
+    skos:definition "Physical state of charge of the high voltage battery. This is not necessarily the state of charge being displayed to the customer."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.StateOfCharge.Current"@en .
+
+vsso:StateOfChargeDisplayed a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "StateOfChargeDisplayed"@en ;
+    skos:definition "State of charge displayed to the customer."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.StateOfCharge.Displayed"@en .
+
+vsso:StateOfChargeTarget a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "StateOfChargeTarget"@en ;
+    skos:definition "Target state of charge set (eg. by customer)."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.StateOfCharge.Target"@en .
+
+vsso:StationAirDistribution a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "StationAirDistribution"@en ;
+    skos:definition "Direction of airstream"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.HVAC.Station.AirDistribution"@en .
+
+vsso:StationFanSpeed a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "StationFanSpeed"@en ;
+    skos:definition "Fan Speed, 0 = off. 100 = max"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.HVAC.Station.FanSpeed"@en .
+
+vsso:StationTemperature a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "StationTemperature"@en ;
+    skos:definition "Temperature"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.HVAC.Station.Temperature"@en .
+
+vsso:StatusDTCCount a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "StatusDTCCount"@en ;
+    skos:definition "Number of sensor Trouble Codes (DTC)"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.Status.DTCCount"@en .
+
+vsso:StatusIgnitionType a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "StatusIgnitionType"@en ;
+    skos:definition "Type of the ignition for ICE - spark = spark plug ignition, compression = self-igniting (Diesel engines)"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.Status.IgnitionType"@en .
+
+vsso:StatusMIL a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "StatusMIL"@en ;
+    skos:definition "Malfunction Indicator Light (MIL) False = Off, True = On"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.Status.MIL"@en .
+
+vsso:SteeringWheelAngle a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "SteeringWheelAngle"@en ;
+    skos:definition "Steering wheel angle. Positive = degrees to the left. Negative = degrees to the right."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.SteeringWheel.Angle"@en .
+
+vsso:SteeringWheelExtension a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "SteeringWheelExtension"@en ;
+    skos:definition "Steering wheel column extension from dashboard. 0 = Closest to dashboard. 100 = Furthest from dashboard."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.SteeringWheel.Extension"@en .
+
+vsso:SteeringWheelPosition a owl:Class ;
+    rdfs:label "SteeringWheelPosition"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:ChassisSteeringWheel ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Position of the steering wheel on the left or right side of the vehicle."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.SteeringWheel.Position"@en .
+
+vsso:SteeringWheelTilt a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "SteeringWheelTilt"@en ;
+    skos:definition "Steering wheel column tilt. 0 = Lowest position. 100 = Highest position."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.SteeringWheel.Tilt"@en .
+
+vsso:SunroofPosition a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "SunroofPosition"@en ;
+    skos:definition "Sunroof position. 0 = Fully closed 100 = Fully opened. -100 = Fully tilted"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Sunroof.Position"@en .
 
 vsso:SunroofShade a owl:Class ;
     rdfs:label "SunroofShade"@en ;
-    rdfs:comment "Sun roof shade status"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:CabinSunroof ;
             owl:onProperty vsso-core:partOf ],
         vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Cabin.Sunroof.Shade"@en .
+    skos:definition "Sun roof shade status"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Sunroof.Shade"@en .
+
+vsso:SunroofSwitch a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "SunroofSwitch"@en ;
+    skos:definition "Switch controlling sliding action such as window, sunroof, or shade."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Sunroof.Switch"@en .
+
+vsso:SwitchBackward a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "SwitchBackward"@en ;
+    skos:definition "Seat backward switch engaged (SingleSeat.Position)"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Backward"@en .
+
+vsso:SwitchCooler a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "SwitchCooler"@en ;
+    skos:definition "Cooler switch for Seat heater (SingleSeat.Heating)"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Cooler"@en .
+
+vsso:SwitchCushion a owl:Class ;
+    rdfs:label "SwitchCushion"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:SeatSwitch ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Switches for SingleSeat.Cushion"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Cushion"@en .
+
+vsso:SwitchDown a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "SwitchDown"@en ;
+    skos:definition "Seat down switch engaged (SingleSeat.Height)"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Down"@en .
+
+vsso:SwitchForward a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "SwitchForward"@en ;
+    skos:definition "Seat forward switch engaged (SingleSeat.Position)"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Forward"@en .
 
 vsso:SwitchHeadRestraint a owl:Class ;
     rdfs:label "SwitchHeadRestraint"@en ;
-    rdfs:comment "Switches for SingleSeat.HeadRestraint.Height"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:SeatSwitch ;
             owl:onProperty vsso-core:partOf ],
         vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Cabin.Seat.Switch.HeadRestraint"@en .
+    skos:definition "Switches for SingleSeat.HeadRestraint.Height"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.HeadRestraint"@en .
+
+vsso:SwitchLumbar a owl:Class ;
+    rdfs:label "SwitchLumbar"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:SeatSwitch ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Switches for SingleSeat.Lumbar"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Lumbar"@en .
 
 vsso:SwitchMassage a owl:Class ;
     rdfs:label "SwitchMassage"@en ;
-    rdfs:comment "Switches for SingleSeat.Massage"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:SeatSwitch ;
             owl:onProperty vsso-core:partOf ],
         vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Cabin.Seat.Switch.Massage"@en .
+    skos:definition "Switches for SingleSeat.Massage"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Massage"@en .
 
 vsso:SwitchRecline a owl:Class ;
     rdfs:label "SwitchRecline"@en ;
-    rdfs:comment "Switches for SingleSeat.Recline"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:SeatSwitch ;
             owl:onProperty vsso-core:partOf ],
         vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Cabin.Seat.Switch.Recline"@en .
+    skos:definition "Switches for SingleSeat.Recline"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Recline"@en .
 
 vsso:SwitchSideBolster a owl:Class ;
     rdfs:label "SwitchSideBolster"@en ;
-    rdfs:comment "Switches for SingleSeat.SideBolster"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:SeatSwitch ;
             owl:onProperty vsso-core:partOf ],
         vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Cabin.Seat.Switch.SideBolster"@en .
+    skos:definition "Switches for SingleSeat.SideBolster"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.SideBolster"@en .
 
-vsso:WindshieldWasherFluid a owl:Class ;
-    rdfs:label "WindshieldWasherFluid"@en ;
-    rdfs:comment "Windshield washer fluid signals"@en ;
+vsso:SwitchUp a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "SwitchUp"@en ;
+    skos:definition "Seat up switch engaged (SingleSeat.Height)"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Up"@en .
+
+vsso:SwitchWarmer a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "SwitchWarmer"@en ;
+    skos:definition "Warmer switch for Seat heater (SingleSeat.Heating)"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Warmer"@en .
+
+vsso:TCSError a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "TCSError"@en ;
+    skos:definition "Indicates if TCS incurred an error condition. True = Error. False = No Error."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.ADAS.TCS.Error"@en .
+
+vsso:TCSIsActive a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "TCSIsActive"@en ;
+    skos:definition "Indicates if TCS is enabled. True = Enabled. False = Disabled."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.ADAS.TCS.IsActive"@en .
+
+vsso:TCSIsEngaged a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "TCSIsEngaged"@en ;
+    skos:definition "Indicates if TCS is currently regulating traction. True = Engaged. False = Not Engaged."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.ADAS.TCS.IsEngaged"@en .
+
+vsso:TimerMode a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "TimerMode"@en ;
+    skos:definition "Defines whether Timer.Time is defining start- or endtime of a charging action; departuretime denotes that target time should be taken from vehicle-level desired departure-time setting."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Charging.Timer.Mode"@en .
+
+vsso:TimerTime a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "TimerTime"@en ;
+    skos:definition "Time value for next charging-related action (Unix timestamp, seconds)."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Charging.Timer.Time"@en .
+
+vsso:TirePressure a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "TirePressure"@en ;
+    skos:definition "Tire pressure in kilo-Pascal"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle.Wheel.Tire.Pressure"@en .
+
+vsso:TirePressureLow a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "TirePressureLow"@en ;
+    skos:definition "Tire Pressure Status. True = Low tire pressure. False = Good tire pressure."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle.Wheel.Tire.PressureLow"@en .
+
+vsso:TireTemperature a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "TireTemperature"@en ;
+    skos:definition "Tire temperature in Celsius."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle.Wheel.Tire.Temperature"@en .
+
+vsso:Trailer a owl:Class ;
+    rdfs:label "Trailer"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso-core:Vehicle ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Trailer signals"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Trailer"@en .
+
+vsso:TrailerConnected a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "TrailerConnected"@en ;
+    skos:definition "Signal indicating if trailer is connected or not."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Trailer.Connected"@en .
+
+vsso:TransmissionClutchWear a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "TransmissionClutchWear"@en ;
+    skos:definition "Clutch wear as a percent. 0 = no wear. 100 = worn."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Transmission.ClutchWear"@en .
+
+vsso:TransmissionCurrentGear a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "TransmissionCurrentGear"@en ;
+    skos:definition "The current gear. 0=Neutral, 1/2/..=Forward, -1/..=Reverse"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Transmission.CurrentGear"@en .
+
+vsso:TransmissionDriveType a owl:Class ;
+    rdfs:label "TransmissionDriveType"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:PowertrainTransmission ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Drive type."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Transmission.DriveType"@en .
+
+vsso:TransmissionGear a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "TransmissionGear"@en ;
+    skos:definition "Current gear. 0=Neutral. -1=Reverse"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Transmission.Gear"@en .
+
+vsso:TransmissionGearChangeMode a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "TransmissionGearChangeMode"@en ;
+    skos:definition "Is the gearbox in automatic or manual (paddle) mode."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Transmission.GearChangeMode"@en .
+
+vsso:TransmissionGearCount a owl:Class ;
+    rdfs:label "TransmissionGearCount"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:PowertrainTransmission ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Number of forward gears in the transmission. -1 = CVT."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Transmission.GearCount"@en .
+
+vsso:TransmissionPerformanceMode a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "TransmissionPerformanceMode"@en ;
+    skos:definition "Current gearbox performance mode."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Transmission.PerformanceMode"@en .
+
+vsso:TransmissionSelectedGear a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "TransmissionSelectedGear"@en ;
+    skos:definition "The selected gear. 0=Neutral, 1/2/..=Forward, -1/..=Reverse, 126=Park, 127=Drive"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Transmission.SelectedGear"@en .
+
+vsso:TransmissionSpeed a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "TransmissionSpeed"@en ;
+    skos:definition "Vehicle speed, as sensed by the gearbox."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Transmission.Speed"@en .
+
+vsso:TransmissionTemperature a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "TransmissionTemperature"@en ;
+    skos:definition "The current gearbox temperature"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Transmission.Temperature"@en .
+
+vsso:TransmissionTravelledDistance a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "TransmissionTravelledDistance"@en ;
+    skos:definition "Odometer reading, total distance travelled during the lifetime of the transmission."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Transmission.TravelledDistance"@en .
+
+vsso:TransmissionType a owl:Class ;
+    rdfs:label "TransmissionType"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:PowertrainTransmission ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Transmission type."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Transmission.Type"@en .
+
+vsso:TravelledDistance a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "TravelledDistance"@en ;
+    skos:definition "Odometer reading, total distance travelled during the lifetime of the vehicle."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.TravelledDistance"@en .
+
+vsso:TripMeterReading a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "TripMeterReading"@en ;
+    skos:definition "Current trip meter reading"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.TripMeterReading"@en .
+
+vsso:TrunkIsLocked a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "TrunkIsLocked"@en ;
+    skos:definition "Is trunk locked or unlocked. True = Locked. False = Unlocked."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Trunk.IsLocked"@en .
+
+vsso:TrunkIsOpen a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "TrunkIsOpen"@en ;
+    skos:definition "Trunk open or closed. True = Open. False = Closed"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Trunk.IsOpen"@en .
+
+vsso:Vehicle rdfs:label "Vehicle"@en ;
+    skos:definition "High-level vehicle data."@en ;
+    vsso-core:vssFacetedClassification "Vehicle"@en .
+
+vsso:VehicleIdentificationACRISSCode a owl:Class ;
+    rdfs:label "VehicleIdentificationACRISSCode"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:VehicleIdentification ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "The ACRISS Car Classification Code is a code used by many car rental companies."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification.ACRISSCode"@en .
+
+vsso:VehicleIdentificationBrand a owl:Class ;
+    rdfs:label "VehicleIdentificationBrand"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:VehicleIdentification ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Vehicle brand or manufacturer"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification.Brand"@en .
+
+vsso:VehicleIdentificationModel a owl:Class ;
+    rdfs:label "VehicleIdentificationModel"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:VehicleIdentification ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Vehicle model"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification.Model"@en .
+
+vsso:VehicleIdentificationVIN a owl:Class ;
+    rdfs:label "VehicleIdentificationVIN"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:VehicleIdentification ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "17-character Vehicle Identification Number (VIN) as defined by ISO 3779"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification.VIN"@en .
+
+vsso:VehicleIdentificationWMI a owl:Class ;
+    rdfs:label "VehicleIdentificationWMI"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:VehicleIdentification ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "3-character World Manufacturer Identification (WMI) as defined by ISO 3780"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification.WMI"@en .
+
+vsso:VehicleIdentificationYear a owl:Class ;
+    rdfs:label "VehicleIdentificationYear"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:VehicleIdentification ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Model year of the vehicle"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification.Year"@en .
+
+vsso:VehicleIdentificationbodyType a owl:Class ;
+    rdfs:label "VehicleIdentificationbodyType"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:VehicleIdentification ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Indicates the design and body style of the vehicle (e.g. station wagon, hatchback, etc.)."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification.bodyType"@en .
+
+vsso:VehicleIdentificationdateVehicleFirstRegistered a owl:Class ;
+    rdfs:label "VehicleIdentificationdateVehicleFirstRegistered"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:VehicleIdentification ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "The date of the first registration of the vehicle with the respective public authorities."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification.dateVehicleFirstRegistered"@en .
+
+vsso:VehicleIdentificationknownVehicleDamages a owl:Class ;
+    rdfs:label "VehicleIdentificationknownVehicleDamages"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:VehicleIdentification ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "A textual description of known damages, both repaired and unrepaired."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification.knownVehicleDamages"@en .
+
+vsso:VehicleIdentificationmeetsEmissionStandard a owl:Class ;
+    rdfs:label "VehicleIdentificationmeetsEmissionStandard"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:VehicleIdentification ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Indicates that the vehicle meets the respective emission standard."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification.meetsEmissionStandard"@en .
+
+vsso:VehicleIdentificationproductionDate a owl:Class ;
+    rdfs:label "VehicleIdentificationproductionDate"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:VehicleIdentification ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "The date of production of the item, e.g. vehicle."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification.productionDate"@en .
+
+vsso:VehicleIdentificationpurchaseDate a owl:Class ;
+    rdfs:label "VehicleIdentificationpurchaseDate"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:VehicleIdentification ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "The date the item e.g. vehicle was purchased by the current owner."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification.purchaseDate"@en .
+
+vsso:VehicleIdentificationvehicleConfiguration a owl:Class ;
+    rdfs:label "VehicleIdentificationvehicleConfiguration"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:VehicleIdentification ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "A short text indicating the configuration of the vehicle, e.g. '5dr hatchback ST 2.5 MT 225 hp' or 'limited edition'."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification.vehicleConfiguration"@en .
+
+vsso:VehicleIdentificationvehicleModelDate a owl:Class ;
+    rdfs:label "VehicleIdentificationvehicleModelDate"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:VehicleIdentification ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "The release date of a vehicle model (often used to differentiate versions of the same make and model)."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification.vehicleModelDate"@en .
+
+vsso:VehicleIdentificationvehicleSeatingCapacity a owl:Class ;
+    rdfs:label "VehicleIdentificationvehicleSeatingCapacity"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:VehicleIdentification ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "The number of passengers that can be seated in the vehicle, both in terms of the physical space available, and in terms of limitations set by law."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification.vehicleSeatingCapacity"@en .
+
+vsso:VehicleIdentificationvehicleSpecialUsage a owl:Class ;
+    rdfs:label "VehicleIdentificationvehicleSpecialUsage"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:VehicleIdentification ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Indicates whether the vehicle has been used for special purposes, like commercial rental, driving school."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification.vehicleSpecialUsage"@en .
+
+vsso:VehicleIdentificationvehicleinteriorColor a owl:Class ;
+    rdfs:label "VehicleIdentificationvehicleinteriorColor"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:VehicleIdentification ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "The color or color combination of the interior of the vehicle."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification.vehicleinteriorColor"@en .
+
+vsso:VehicleIdentificationvehicleinteriorType a owl:Class ;
+    rdfs:label "VehicleIdentificationvehicleinteriorType"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:VehicleIdentification ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "The type or material of the interior of the vehicle (e.g. synthetic fabric, leather, wood, etc.)."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification.vehicleinteriorType"@en .
+
+vsso:VersionVSSLabel a owl:Class ;
+    rdfs:label "VersionVSSLabel"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:VersionVSS ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Label to further describe the version"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.VersionVSS.Label"@en .
+
+vsso:VersionVSSMajor a owl:Class ;
+    rdfs:label "VersionVSSMajor"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:VersionVSS ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Supported Version of VSS - Major version"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.VersionVSS.Major"@en .
+
+vsso:VersionVSSMinor a owl:Class ;
+    rdfs:label "VersionVSSMinor"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:VersionVSS ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Supported Version of VSS - Minor version"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.VersionVSS.Minor"@en .
+
+vsso:VersionVSSPatch a owl:Class ;
+    rdfs:label "VersionVSSPatch"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:VersionVSS ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Supported Version of VSS - Patch version"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.VersionVSS.Patch"@en .
+
+vsso:WasherFluidLevel a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "WasherFluidLevel"@en ;
+    skos:definition "Washer fluid level as a percent. 0 = Empty. 100 = Full."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Windshield.WasherFluid.Level"@en .
+
+vsso:WasherFluidLevelLow a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "WasherFluidLevelLow"@en ;
+    skos:definition "Low level indication for washer fluid. True = Level Low. False = Level OK."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Windshield.WasherFluid.LevelLow"@en .
+
+vsso:WheelBrake a owl:Class ;
+    rdfs:label "WheelBrake"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:AxleWheel ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Brake signals for wheel"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle.Wheel.Brake"@en .
+
+vsso:WheelTire a owl:Class ;
+    rdfs:label "WheelTire"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:AxleWheel ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Tire signals for wheel"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle.Wheel.Tire"@en .
+
+vsso:Width a owl:Class ;
+    rdfs:label "Width"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso-core:Vehicle ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "Overall vehicle width."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Width"@en .
+
+vsso:WindowChildLock a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "WindowChildLock"@en ;
+    skos:definition "Is window child lock engaged. True = Engaged. False = Disengaged."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Door.Window.ChildLock"@en .
+
+vsso:WindowPosition a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "WindowPosition"@en ;
+    skos:definition "Window position. 0 = Fully closed 100 = Fully opened."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Door.Window.Position"@en .
+
+vsso:WindowSwitch a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "WindowSwitch"@en ;
+    skos:definition "Switch controlling sliding action such as window, sunroof, or blind."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Door.Window.Switch"@en .
+
+vsso:WindowisOpen a vsso-core:ObservableVehicleProperty ;
+    rdfs:label "WindowisOpen"@en ;
+    skos:definition "Is window open or closed"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Door.Window.isOpen"@en .
+
+vsso:WindshieldHeating a owl:Class ;
+    rdfs:label "WindshieldHeating"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:BodyWindshield ;
             owl:onProperty vsso-core:partOf ],
         vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Body.Windshield.WasherFluid"@en .
+    skos:definition "Windshield heater signals"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Windshield.Heating"@en .
 
-vsso:ADASABS a owl:Class ;
-    rdfs:label "ADASABS"@en ;
-    rdfs:comment "Antilock Braking System signals"@en ;
+vsso:WindshieldWasherFluid a owl:Class ;
+    rdfs:label "WindshieldWasherFluid"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ADAS ;
+            owl:allValuesFrom vsso:BodyWindshield ;
             owl:onProperty vsso-core:partOf ],
         vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.ADAS.ABS"@en .
+    skos:definition "Windshield washer fluid signals"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Windshield.WasherFluid"@en .
 
-vsso:ADASCruiseControl a owl:Class ;
-    rdfs:label "ADASCruiseControl"@en ;
-    rdfs:comment "Signals from Cruise Control system"@en ;
+vsso:WindshieldWiping a owl:Class ;
+    rdfs:label "WindshieldWiping"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ADAS ;
+            owl:allValuesFrom vsso:BodyWindshield ;
             owl:onProperty vsso-core:partOf ],
         vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.ADAS.CruiseControl"@en .
+    skos:definition "Windshield wiper signals"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Windshield.Wiping"@en .
 
-vsso:ADASESC a owl:Class ;
-    rdfs:label "ADASESC"@en ;
-    rdfs:comment "Electronic Stability Control System signals"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ADAS ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.ADAS.ESC"@en .
+vsso:WipingStatus a vsso-core:ActuatableVehicleProperty,
+        vsso-core:ObservableVehicleProperty ;
+    rdfs:label "WipingStatus"@en ;
+    skos:definition "Wiper status"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Windshield.Wiping.Status"@en .
 
-vsso:ADASLaneDepartureDetection a owl:Class ;
-    rdfs:label "ADASLaneDepartureDetection"@en ;
-    rdfs:comment "Signals from Land Departure Detection System"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ADAS ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.ADAS.LaneDepartureDetection"@en .
-
-vsso:ADASTCS a owl:Class ;
-    rdfs:label "ADASTCS"@en ;
-    rdfs:comment "Traction Control System signals"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ADAS ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.ADAS.TCS"@en .
-
-vsso:Acceleration a owl:Class ;
-    rdfs:label "Acceleration"@en ;
-    rdfs:comment "Spatial acceleration"@en ;
+vsso:accelerationTime a owl:Class ;
+    rdfs:label "accelerationTime"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Acceleration"@en .
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "The time needed to accelerate the vehicle from a given start velocity to a given target velocity."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.accelerationTime"@en .
 
-vsso:AngularVelocity a owl:Class ;
-    rdfs:label "AngularVelocity"@en ;
-    rdfs:comment "Spatial rotation"@en ;
+vsso:cargoVolume a owl:Class ;
+    rdfs:label "cargoVolume"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.AngularVelocity"@en .
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "The available volume for cargo or luggage. For automobiles, this is usually the trunk volume."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.cargoVolume"@en .
 
-vsso:BatteryStateOfCharge a owl:Class ;
-    rdfs:label "BatteryStateOfCharge"@en ;
-    rdfs:comment "Information on the state of charge of the vehicle's high voltage battery."@en ;
+vsso:emissionsCO2 a owl:Class ;
+    rdfs:label "emissionsCO2"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainBattery ;
+            owl:allValuesFrom vsso-core:Vehicle ;
+            owl:onProperty vsso-core:belongsToVehicleComponent ],
+        vsso-core:StaticVehicleProperty ;
+    skos:definition "The CO2 emissions."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.emissionsCO2"@en .
+
+vsso:BodyChargingPort a owl:Class ;
+    rdfs:label "BodyChargingPort"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:Body ;
             owl:onProperty vsso-core:partOf ],
         vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Powertrain.Battery.StateOfCharge"@en .
+    skos:definition "Collects Information about the charging port"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.ChargingPort"@en .
 
 vsso:BodyMirrors a owl:Class ;
     rdfs:label "BodyMirrors"@en ;
-    rdfs:comment "All mirrors"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:Body ;
             owl:onProperty vsso-core:partOf ],
         vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Body.Mirrors"@en .
-
-vsso:BodyWindshield a owl:Class ;
-    rdfs:label "BodyWindshield"@en ;
-    rdfs:comment "Windshield signals"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Body ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Body.Windshield"@en .
-
-vsso:CabinInfotainment a owl:Class ;
-    rdfs:label "CabinInfotainment"@en ;
-    rdfs:comment "Infotainment system"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Cabin ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Cabin.Infotainment"@en .
-
-vsso:CabinSunroof a owl:Class ;
-    rdfs:label "CabinSunroof"@en ;
-    rdfs:comment "Sun roof status."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Cabin ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Cabin.Sunroof"@en .
-
-vsso:CombustionEngineDieselParticulateFilter a owl:Class ;
-    rdfs:label "CombustionEngineDieselParticulateFilter"@en ;
-    rdfs:comment "Diesel Particulate Filter signals"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Powertrain.CombustionEngine.DieselParticulateFilter"@en .
-
-vsso:HVACStation a owl:Class ;
-    rdfs:label "HVACStation"@en ;
-    rdfs:comment "HVAC for single station in the vehicle"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinHVAC ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Cabin.HVAC.Station"@en .
-
-vsso:LightsSpotlight a owl:Class ;
-    rdfs:label "LightsSpotlight"@en ;
-    rdfs:comment "Spotlight for a specific area in the vehicle."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinLights ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Cabin.Lights.Spotlight"@en .
-
-vsso:OBDDriveCycleStatus a owl:Class ;
-    rdfs:label "OBDDriveCycleStatus"@en ;
-    rdfs:comment "PID 41 - OBD status for the current drive cycle"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.OBD.DriveCycleStatus"@en .
-
-vsso:OBDO2WR a owl:Class ;
-    rdfs:label "OBDO2WR"@en ;
-    rdfs:comment "Wide range/band oxygen sensors (PID 24 - 2B and PID 34 - 3B)"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.OBD.O2WR"@en .
-
-vsso:OBDStatus a owl:Class ;
-    rdfs:label "OBDStatus"@en ;
-    rdfs:comment "PID 01 - OBD status"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.OBD.Status"@en .
-
-vsso:Service a owl:Class ;
-    rdfs:label "Service"@en ;
-    rdfs:comment "Service data."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Service"@en .
-
-vsso:WheelTire a owl:Class ;
-    rdfs:label "WheelTire"@en ;
-    rdfs:comment "Tire signals for wheel"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:AxleWheel ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Chassis.Axle.Wheel.Tire"@en .
-
-vsso:ChassisSteeringWheel a owl:Class ;
-    rdfs:label "ChassisSteeringWheel"@en ;
-    rdfs:comment "Steering wheel signals"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Chassis ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Chassis.SteeringWheel"@en .
-
-vsso:DoorWindow a owl:Class ;
-    rdfs:label "DoorWindow"@en ;
-    rdfs:comment "Door window status"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinDoor ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Cabin.Door.Window"@en .
-
-vsso:SwitchCushion a owl:Class ;
-    rdfs:label "SwitchCushion"@en ;
-    rdfs:comment "Switches for SingleSeat.Cushion"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SeatSwitch ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Cabin.Seat.Switch.Cushion"@en .
-
-vsso:SwitchLumbar a owl:Class ;
-    rdfs:label "SwitchLumbar"@en ;
-    rdfs:comment "Switches for SingleSeat.Lumbar"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SeatSwitch ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Cabin.Seat.Switch.Lumbar"@en .
-
-vsso:VersionVSS a owl:Class ;
-    rdfs:label "VersionVSS"@en ;
-    rdfs:comment "Supported Version of VSS"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.VersionVSS"@en .
-
-vsso:WheelBrake a owl:Class ;
-    rdfs:label "WheelBrake"@en ;
-    rdfs:comment "Brake signals for wheel"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:AxleWheel ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Chassis.Axle.Wheel.Brake"@en .
-
-vsso:CabinDoor a owl:Class ;
-    rdfs:label "CabinDoor"@en ;
-    rdfs:comment "All doors, including windows and switches"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Cabin ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Cabin.Door"@en .
-
-vsso:CurrentLocation a owl:Class ;
-    rdfs:label "CurrentLocation"@en ;
-    rdfs:comment "The current latitude and longitude of the vehicle."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.CurrentLocation"@en .
-
-vsso:ElectricMotorMotor a owl:Class ;
-    rdfs:label "ElectricMotorMotor"@en ;
-    rdfs:comment "motor signals"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainElectricMotor ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Powertrain.ElectricMotor.Motor"@en .
-
-vsso:InfotainmentMedia a owl:Class ;
-    rdfs:label "InfotainmentMedia"@en ;
-    rdfs:comment "All Media actions"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinInfotainment ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Cabin.Infotainment.Media"@en .
-
-vsso:MediaPlayed a owl:Class ;
-    rdfs:label "MediaPlayed"@en ;
-    rdfs:comment "Collection of signals updated in concert when a new media is played"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:InfotainmentMedia ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Cabin.Infotainment.Media.Played"@en .
-
-vsso:PowertrainElectricMotor a owl:Class ;
-    rdfs:label "PowertrainElectricMotor"@en ;
-    rdfs:comment "Electric Motor specific data."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Powertrain ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Powertrain.ElectricMotor"@en .
-
-vsso:ADAS a owl:Class ;
-    rdfs:label "ADAS"@en ;
-    rdfs:comment "All Advanced Driver Assist Systems data."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.ADAS"@en .
+    skos:definition "All mirrors"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Mirrors"@en .
 
 vsso:CabinHVAC a owl:Class ;
     rdfs:label "CabinHVAC"@en ;
-    rdfs:comment "Climate control"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:Cabin ;
             owl:onProperty vsso-core:partOf ],
         vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Cabin.HVAC"@en .
+    skos:definition "Climate control"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.HVAC"@en .
 
 vsso:CabinLights a owl:Class ;
     rdfs:label "CabinLights"@en ;
-    rdfs:comment "Interior lights signals and sensors"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:Cabin ;
             owl:onProperty vsso-core:partOf ],
         vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Cabin.Lights"@en .
+    skos:definition "Interior lights signals and sensors"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Lights"@en .
 
-vsso:Driver a owl:Class ;
-    rdfs:label "Driver"@en ;
-    rdfs:comment "Driver data."@en ;
+vsso:CabinSunroof a owl:Class ;
+    rdfs:label "CabinSunroof"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
+            owl:allValuesFrom vsso:Cabin ;
             owl:onProperty vsso-core:partOf ],
         vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Driver"@en .
+    skos:definition "Sun roof status."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Sunroof"@en .
 
-vsso:NavigationCurrentLocation a owl:Class ;
-    rdfs:label "NavigationCurrentLocation"@en ;
-    rdfs:comment "The current latitude and longitude of the vehicle."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:InfotainmentNavigation ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Cabin.Infotainment.Navigation.CurrentLocation"@en .
-
-vsso:ChassisAxle a owl:Class ;
-    rdfs:label "ChassisAxle"@en ;
-    rdfs:comment "Axle signals"@en ;
+vsso:ChassisSteeringWheel a owl:Class ;
+    rdfs:label "ChassisSteeringWheel"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:Chassis ;
             owl:onProperty vsso-core:partOf ],
         vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Chassis.Axle"@en .
+    skos:definition "Steering wheel signals"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.SteeringWheel"@en .
 
-vsso:Powertrain a owl:Class ;
-    rdfs:label "Powertrain"@en ;
-    rdfs:comment "Powertrain data for battery management, etc."@en ;
+vsso:Driver a owl:Class ;
+    rdfs:label "Driver"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso-core:Vehicle ;
             owl:onProperty vsso-core:partOf ],
         vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Powertrain"@en .
+    skos:definition "Driver data."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Driver"@en .
 
-vsso:InfotainmentHMI a owl:Class ;
-    rdfs:label "InfotainmentHMI"@en ;
-    rdfs:comment "HMI related signals"@en ;
+vsso:InfotainmentMedia a owl:Class ;
+    rdfs:label "InfotainmentMedia"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:CabinInfotainment ;
             owl:onProperty vsso-core:partOf ],
         vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Cabin.Infotainment.HMI"@en .
+    skos:definition "All Media actions"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Media"@en .
 
-vsso:CombustionEngineEngine a owl:Class ;
-    rdfs:label "CombustionEngineEngine"@en ;
-    rdfs:comment "Engine signals"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Powertrain.CombustionEngine.Engine"@en .
-
-vsso:Body a owl:Class ;
-    rdfs:label "Body"@en ;
-    rdfs:comment "All body components."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Body"@en .
-
-vsso:BodyLights a owl:Class ;
-    rdfs:label "BodyLights"@en ;
-    rdfs:comment "All lights"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Body ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Body.Lights"@en .
-
-vsso:PowertrainFuelSystem a owl:Class ;
-    rdfs:label "PowertrainFuelSystem"@en ;
-    rdfs:comment "Fuel system data."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Powertrain ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Powertrain.FuelSystem"@en .
-
-vsso:PowertrainBattery a owl:Class ;
-    rdfs:label "PowertrainBattery"@en ;
-    rdfs:comment "Battery Management data."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Powertrain ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Powertrain.Battery"@en .
-
-vsso:PowertrainTransmission a owl:Class ;
-    rdfs:label "PowertrainTransmission"@en ;
-    rdfs:comment "Transmission-specific data, stopping at the drive shafts."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Powertrain ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Powertrain.Transmission"@en .
-
-vsso:SeatSwitch a owl:Class ;
-    rdfs:label "SeatSwitch"@en ;
-    rdfs:comment "Seat switch signals"@en ;
+vsso:SeatOccupant a owl:Class ;
+    rdfs:label "SeatOccupant"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:CabinSeat ;
             owl:onProperty vsso-core:partOf ],
         vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Cabin.Seat.Switch"@en .
+    skos:definition "Occupant data."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Occupant"@en .
+
+vsso:AxleWheel a owl:Class ;
+    rdfs:label "AxleWheel"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:ChassisAxle ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Wheel signals for axle"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle.Wheel"@en .
 
 vsso:BatteryCharging a owl:Class ;
     rdfs:label "BatteryCharging"@en ;
-    rdfs:comment "Properties related to battery charging"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:PowertrainBattery ;
             owl:onProperty vsso-core:partOf ],
         vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Powertrain.Battery.Charging"@en .
+    skos:definition "Properties related to battery charging"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Charging"@en .
 
-vsso:Cabin a owl:Class ;
-    rdfs:label "Cabin"@en ;
-    rdfs:comment "All in-cabin components, including doors."@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Cabin"@en .
-
-vsso:CabinSeat a owl:Class ;
-    rdfs:label "CabinSeat"@en ;
-    rdfs:comment "All seats."@en ;
+vsso:CabinDoor a owl:Class ;
+    rdfs:label "CabinDoor"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:Cabin ;
             owl:onProperty vsso-core:partOf ],
         vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Cabin.Seat"@en .
+    skos:definition "All doors, including windows and switches"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Door"@en .
 
-vsso:Chassis a owl:Class ;
-    rdfs:label "Chassis"@en ;
-    rdfs:comment "All data concerning steering, suspension, wheels, and brakes."@en ;
+vsso:InfotainmentNavigation a owl:Class ;
+    rdfs:label "InfotainmentNavigation"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
+            owl:allValuesFrom vsso:CabinInfotainment ;
             owl:onProperty vsso-core:partOf ],
         vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Chassis"@en .
+    skos:definition "All navigation actions"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Navigation"@en .
 
-vsso:PowertrainCombustionEngine a owl:Class ;
-    rdfs:label "PowertrainCombustionEngine"@en ;
-    rdfs:comment "Engine-specific data, stopping at the bell housing."@en ;
+vsso:OBDCatalyst a owl:Class ;
+    rdfs:label "OBDCatalyst"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:OBD ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Catalyst signals"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.Catalyst"@en .
+
+vsso:BodyWindshield a owl:Class ;
+    rdfs:label "BodyWindshield"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:Body ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Windshield signals"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Windshield"@en .
+
+vsso:CabinInfotainment a owl:Class ;
+    rdfs:label "CabinInfotainment"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:Cabin ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Infotainment system"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment"@en .
+
+vsso:PowertrainFuelSystem a owl:Class ;
+    rdfs:label "PowertrainFuelSystem"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso:Powertrain ;
             owl:onProperty vsso-core:partOf ],
         vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.Powertrain.CombustionEngine"@en .
+    skos:definition "Fuel system data."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.FuelSystem"@en .
 
-vsso:VehicleIdentification a owl:Class ;
-    rdfs:label "VehicleIdentification"@en ;
-    rdfs:comment "Attributes that identify a vehicle"@en ;
+vsso:PowertrainTransmission a owl:Class ;
+    rdfs:label "PowertrainTransmission"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:Powertrain ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Transmission-specific data, stopping at the drive shafts."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Transmission"@en .
+
+vsso:VersionVSS a owl:Class ;
+    rdfs:label "VersionVSS"@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso-core:Vehicle ;
             owl:onProperty vsso-core:partOf ],
         vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.VehicleIdentification"@en .
+    skos:definition "Supported Version of VSS"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.VersionVSS"@en .
+
+vsso:Powertrain a owl:Class ;
+    rdfs:label "Powertrain"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso-core:Vehicle ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Powertrain data for battery management, etc."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain"@en .
+
+vsso:PowertrainElectricMotor a owl:Class ;
+    rdfs:label "PowertrainElectricMotor"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:Powertrain ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Electric Motor specific data."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.ElectricMotor"@en .
+
+vsso:ADAS a owl:Class ;
+    rdfs:label "ADAS"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso-core:Vehicle ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "All Advanced Driver Assist Systems data."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.ADAS"@en .
 
 vsso:OBD a owl:Class ;
     rdfs:label "OBD"@en ;
-    rdfs:comment "OBD data."@en ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom vsso-core:Vehicle ;
             owl:onProperty vsso-core:partOf ],
         vsso-core:VehicleComponent ;
-    skos:altLabel "Vehicle.OBD"@en .
+    skos:definition "OBD data."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD"@en .
+
+vsso:PowertrainBattery a owl:Class ;
+    rdfs:label "PowertrainBattery"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:Powertrain ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Battery Management data."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery"@en .
+
+vsso:SeatSwitch a owl:Class ;
+    rdfs:label "SeatSwitch"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:CabinSeat ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Seat switch signals"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch"@en .
+
+vsso:CabinSeat a owl:Class ;
+    rdfs:label "CabinSeat"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:Cabin ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "All seats."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat"@en .
+
+vsso:ChassisAxle a owl:Class ;
+    rdfs:label "ChassisAxle"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:Chassis ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Axle signals"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle"@en .
+
+vsso:Body a owl:Class ;
+    rdfs:label "Body"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso-core:Vehicle ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "All body components."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Body"@en .
+
+vsso:Cabin a owl:Class ;
+    rdfs:label "Cabin"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso-core:Vehicle ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "All in-cabin components, including doors."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin"@en .
+
+vsso:Chassis a owl:Class ;
+    rdfs:label "Chassis"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso-core:Vehicle ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "All data concerning steering, suspension, wheels, and brakes."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis"@en .
+
+vsso:PowertrainCombustionEngine a owl:Class ;
+    rdfs:label "PowertrainCombustionEngine"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso:Powertrain ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Engine-specific data, stopping at the bell housing."@en ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine"@en .
+
+vsso:VehicleIdentification a owl:Class ;
+    rdfs:label "VehicleIdentification"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom vsso-core:Vehicle ;
+            owl:onProperty vsso-core:partOf ],
+        vsso-core:VehicleComponent ;
+    skos:definition "Attributes that identify a vehicle"@en ;
+    vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification"@en .
 
 

--- a/spec/vss_rel_2.2.ttl
+++ b/spec/vss_rel_2.2.ttl
@@ -3179,7 +3179,8 @@ vsso:CabinSeat a vsso-core:VehicleComponent ;
     vsso-core:partOf vsso:Cabin ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat"@en .
 
-vsso:Vehicle rdfs:label "Vehicle"@en ;
+vsso:Vehicle a vsso-core:VehicleComponent ;
+    rdfs:label "Vehicle"@en ;
     skos:definition "High-level vehicle data."@en ;
     vsso-core:vssFacetedClassification "Vehicle"@en .
 

--- a/spec/vss_rel_2.2.ttl
+++ b/spec/vss_rel_2.2.ttl
@@ -30,481 +30,296 @@ vsso: a owl:Ontology ;
 vsso:ABSError a vsso-core:ObservableVehicleProperty ;
     rdfs:label "ABSError"@en ;
     skos:definition "Indicates if ABS incurred an error condition. True = Error. False = No Error."@en ;
+    vsso-core:belongsToVehicleComponent vsso:ADASABS ;
     vsso-core:vssFacetedClassification "Vehicle.ADAS.ABS.Error"@en .
 
 vsso:ABSIsActive a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "ABSIsActive"@en ;
     skos:definition "Indicates if ABS is enabled. True = Enabled. False = Disabled."@en ;
+    vsso-core:belongsToVehicleComponent vsso:ADASABS ;
     vsso-core:vssFacetedClassification "Vehicle.ADAS.ABS.IsActive"@en .
 
 vsso:ABSIsEngaged a vsso-core:ObservableVehicleProperty ;
     rdfs:label "ABSIsEngaged"@en ;
     skos:definition "Indicates if ABS is currently regulating brake pressure. True = Engaged. False = Not Engaged."@en ;
+    vsso-core:belongsToVehicleComponent vsso:ADASABS ;
     vsso-core:vssFacetedClassification "Vehicle.ADAS.ABS.IsEngaged"@en .
-
-vsso:ADASABS a owl:Class ;
-    rdfs:label "ADASABS"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ADAS ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Antilock Braking System signals"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.ADAS.ABS"@en .
-
-vsso:ADASCruiseControl a owl:Class ;
-    rdfs:label "ADASCruiseControl"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ADAS ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Signals from Cruise Control system"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.ADAS.CruiseControl"@en .
-
-vsso:ADASESC a owl:Class ;
-    rdfs:label "ADASESC"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ADAS ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Electronic Stability Control System signals"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.ADAS.ESC"@en .
-
-vsso:ADASLaneDepartureDetection a owl:Class ;
-    rdfs:label "ADASLaneDepartureDetection"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ADAS ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Signals from Land Departure Detection System"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.ADAS.LaneDepartureDetection"@en .
-
-vsso:ADASObstacleDetection a owl:Class ;
-    rdfs:label "ADASObstacleDetection"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ADAS ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Signals form Obstacle Sensor System"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.ADAS.ObstacleDetection"@en .
-
-vsso:ADASTCS a owl:Class ;
-    rdfs:label "ADASTCS"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ADAS ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Traction Control System signals"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.ADAS.TCS"@en .
-
-vsso:Acceleration a owl:Class ;
-    rdfs:label "Acceleration"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Spatial acceleration"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Acceleration"@en .
 
 vsso:AccelerationLateral a vsso-core:ObservableVehicleProperty ;
     rdfs:label "AccelerationLateral"@en ;
     skos:definition "Vehicle acceleration in Y (lateral acceleration)."@en ;
+    vsso-core:belongsToVehicleComponent vsso:Acceleration ;
     vsso-core:vssFacetedClassification "Vehicle.Acceleration.Lateral"@en .
 
 vsso:AccelerationLongitudinal a vsso-core:ObservableVehicleProperty ;
     rdfs:label "AccelerationLongitudinal"@en ;
     skos:definition "Vehicle acceleration in X (longitudinal acceleration)."@en ;
+    vsso-core:belongsToVehicleComponent vsso:Acceleration ;
     vsso-core:vssFacetedClassification "Vehicle.Acceleration.Longitudinal"@en .
 
 vsso:AccelerationVertical a vsso-core:ObservableVehicleProperty ;
     rdfs:label "AccelerationVertical"@en ;
     skos:definition "Vehicle acceleration in Z (vertical acceleration)."@en ;
+    vsso-core:belongsToVehicleComponent vsso:Acceleration ;
     vsso-core:vssFacetedClassification "Vehicle.Acceleration.Vertical"@en .
 
 vsso:AcceleratorPedalPosition a vsso-core:ObservableVehicleProperty ;
     rdfs:label "AcceleratorPedalPosition"@en ;
     skos:definition "Accelerator pedal position as percent. 0 = Not depressed. 100 = Fully depressed."@en ;
+    vsso-core:belongsToVehicleComponent vsso:ChassisAccelerator ;
     vsso-core:vssFacetedClassification "Vehicle.Chassis.Accelerator.PedalPosition"@en .
 
 vsso:AirbagIsDeployed a vsso-core:ObservableVehicleProperty ;
     rdfs:label "AirbagIsDeployed"@en ;
     skos:definition "Airbag deployment status. True = Airbag deployed. False = Airbag not deployed."@en ;
+    vsso-core:belongsToVehicleComponent vsso:SeatAirbag ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Airbag.IsDeployed"@en .
 
 vsso:AmbientAirTemperature a vsso-core:ObservableVehicleProperty ;
     rdfs:label "AmbientAirTemperature"@en ;
     skos:definition "Ambient air temperature outside the vehicle."@en ;
+    vsso-core:belongsToVehicleComponent vsso:Vehicle ;
     vsso-core:vssFacetedClassification "Vehicle.AmbientAirTemperature"@en .
-
-vsso:AngularVelocity a owl:Class ;
-    rdfs:label "AngularVelocity"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Spatial rotation"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.AngularVelocity"@en .
 
 vsso:AngularVelocityPitch a vsso-core:ObservableVehicleProperty ;
     rdfs:label "AngularVelocityPitch"@en ;
     skos:definition "Vehicle rotation rate along Y (lateral)."@en ;
+    vsso-core:belongsToVehicleComponent vsso:AngularVelocity ;
     vsso-core:vssFacetedClassification "Vehicle.AngularVelocity.Pitch"@en .
 
 vsso:AngularVelocityRoll a vsso-core:ObservableVehicleProperty ;
     rdfs:label "AngularVelocityRoll"@en ;
     skos:definition "Vehicle rotation rate along X (longitudinal)."@en ;
+    vsso-core:belongsToVehicleComponent vsso:AngularVelocity ;
     vsso-core:vssFacetedClassification "Vehicle.AngularVelocity.Roll"@en .
 
 vsso:AngularVelocityYaw a vsso-core:ObservableVehicleProperty ;
     rdfs:label "AngularVelocityYaw"@en ;
     skos:definition "Vehicle rotation rate along Z (vertical)."@en ;
+    vsso-core:belongsToVehicleComponent vsso:AngularVelocity ;
     vsso-core:vssFacetedClassification "Vehicle.AngularVelocity.Yaw"@en .
 
 vsso:AverageSpeed a vsso-core:ObservableVehicleProperty ;
     rdfs:label "AverageSpeed"@en ;
     skos:definition "Average speed for the current trip"@en ;
+    vsso-core:belongsToVehicleComponent vsso:Vehicle ;
     vsso-core:vssFacetedClassification "Vehicle.AverageSpeed"@en .
 
 vsso:AxleTireAspectRatio a owl:Class ;
     rdfs:label "AxleTireAspectRatio"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ChassisAxle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Aspect ratio between tire section height and tire section width, as per ETRTO / TRA standard."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle.TireAspectRatio"@en .
 
 vsso:AxleTireDiameter a owl:Class ;
     rdfs:label "AxleTireDiameter"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ChassisAxle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Outer diameter of tires, in inches, as per ETRTO / TRA standard."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle.TireDiameter"@en .
 
 vsso:AxleTireWidth a owl:Class ;
     rdfs:label "AxleTireWidth"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ChassisAxle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Nominal section width of tires, in mm, as per ETRTO / TRA standard."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle.TireWidth"@en .
 
 vsso:AxleWheelCount a owl:Class ;
     rdfs:label "AxleWheelCount"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ChassisAxle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Number of wheels on the axle"@en ;
     vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle.WheelCount"@en .
 
 vsso:AxleWheelDiameter a owl:Class ;
     rdfs:label "AxleWheelDiameter"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ChassisAxle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Diameter of wheels (rims without tires), in inches, as per ETRTO / TRA standard."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle.WheelDiameter"@en .
 
 vsso:AxleWheelWidth a owl:Class ;
     rdfs:label "AxleWheelWidth"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ChassisAxle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Width of wheels (rims without tires), in inches, as per ETRTO / TRA standard."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle.WheelWidth"@en .
 
 vsso:Bank1Temperature1 a vsso-core:ObservableVehicleProperty ;
     rdfs:label "Bank1Temperature1"@en ;
     skos:definition "PID 3C - Catalyst temperature from bank 1, sensor 1"@en ;
+    vsso-core:belongsToVehicleComponent vsso:CatalystBank1 ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.Catalyst.Bank1.Temperature1"@en .
 
 vsso:Bank1Temperature2 a vsso-core:ObservableVehicleProperty ;
     rdfs:label "Bank1Temperature2"@en ;
     skos:definition "PID 3E - Catalyst temperature from bank 1, sensor 2"@en ;
+    vsso-core:belongsToVehicleComponent vsso:CatalystBank1 ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.Catalyst.Bank1.Temperature2"@en .
 
 vsso:Bank2Temperature1 a vsso-core:ObservableVehicleProperty ;
     rdfs:label "Bank2Temperature1"@en ;
     skos:definition "PID 3D - Catalyst temperature from bank 2, sensor 1"@en ;
+    vsso-core:belongsToVehicleComponent vsso:CatalystBank2 ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.Catalyst.Bank2.Temperature1"@en .
 
 vsso:Bank2Temperature2 a vsso-core:ObservableVehicleProperty ;
     rdfs:label "Bank2Temperature2"@en ;
     skos:definition "PID 3F - Catalyst temperature from bank 2, sensor 2"@en ;
+    vsso-core:belongsToVehicleComponent vsso:CatalystBank2 ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.Catalyst.Bank2.Temperature2"@en .
 
 vsso:BatteryAccumulatedChargedEnergy a vsso-core:ObservableVehicleProperty ;
     rdfs:label "BatteryAccumulatedChargedEnergy"@en ;
     skos:definition "The accumulated energy delivered to the battery during charging over lifetime."@en ;
+    vsso-core:belongsToVehicleComponent vsso:PowertrainBattery ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.AccumulatedChargedEnergy"@en .
 
 vsso:BatteryAccumulatedConsumedEnergy a vsso-core:ObservableVehicleProperty ;
     rdfs:label "BatteryAccumulatedConsumedEnergy"@en ;
     skos:definition "The accumulated energy leaving HV battery for propulsion and auxiliary loads over lifetime."@en ;
+    vsso-core:belongsToVehicleComponent vsso:PowertrainBattery ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.AccumulatedConsumedEnergy"@en .
 
 vsso:BatteryGrossCapacity a owl:Class ;
     rdfs:label "BatteryGrossCapacity"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainBattery ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Gross capacity of the battery"@en ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.GrossCapacity"@en .
 
 vsso:BatteryGroundConnected a vsso-core:ObservableVehicleProperty ;
     rdfs:label "BatteryGroundConnected"@en ;
     skos:definition "Indicating if the ground (negative terminator) of the traction battery is connected to the powertrain."@en ;
+    vsso-core:belongsToVehicleComponent vsso:PowertrainBattery ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.GroundConnected"@en .
 
 vsso:BatteryNetCapacity a owl:Class ;
     rdfs:label "BatteryNetCapacity"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainBattery ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Net capacity of the battery"@en ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.NetCapacity"@en .
 
 vsso:BatteryNominalVoltage a owl:Class ;
     rdfs:label "BatteryNominalVoltage"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainBattery ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Nominal Voltage of the battery"@en ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.NominalVoltage"@en .
 
 vsso:BatteryPowerConnected a vsso-core:ObservableVehicleProperty ;
     rdfs:label "BatteryPowerConnected"@en ;
     skos:definition "Indicating if the power (positive terminator) of the traction battery is connected to the powertrain."@en ;
+    vsso-core:belongsToVehicleComponent vsso:PowertrainBattery ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.PowerConnected"@en .
 
 vsso:BatteryRange a vsso-core:ObservableVehicleProperty ;
     rdfs:label "BatteryRange"@en ;
     skos:definition "Remaining range in meters using only battery."@en ;
+    vsso-core:belongsToVehicleComponent vsso:PowertrainBattery ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Range"@en .
 
 vsso:BatteryReferentVoltage a owl:Class ;
     rdfs:label "BatteryReferentVoltage"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainBattery ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Referent Voltage of the battery"@en ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.ReferentVoltage"@en .
-
-vsso:BatteryStateOfCharge a owl:Class ;
-    rdfs:label "BatteryStateOfCharge"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainBattery ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Information on the state of charge of the vehicle's high voltage battery."@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.StateOfCharge"@en .
 
 vsso:BatteryTemperature a vsso-core:ObservableVehicleProperty ;
     rdfs:label "BatteryTemperature"@en ;
     skos:definition "Temperature of the battery pack"@en ;
+    vsso-core:belongsToVehicleComponent vsso:PowertrainBattery ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Temperature"@en .
 
 vsso:BodyBodyType a owl:Class ;
     rdfs:label "BodyBodyType"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Body ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Body type code as defined by ISO 3779"@en ;
     vsso-core:vssFacetedClassification "Vehicle.Body.BodyType"@en .
 
-vsso:BodyHood a owl:Class ;
-    rdfs:label "BodyHood"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Body ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Hood status"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Body.Hood"@en .
-
-vsso:BodyHorn a owl:Class ;
-    rdfs:label "BodyHorn"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Body ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Horn signals"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Body.Horn"@en .
-
-vsso:BodyLights a owl:Class ;
-    rdfs:label "BodyLights"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Body ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "All lights"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Body.Lights"@en .
-
-vsso:BodyRaindetection a owl:Class ;
-    rdfs:label "BodyRaindetection"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Body ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Rainsensor signals"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Body.Raindetection"@en .
+vsso:BodyChargingPort a vsso-core:VehicleComponent ;
+    rdfs:label "BodyChargingPort"@en ;
+    skos:definition "Collects Information about the charging port"@en ;
+    vsso-core:partOf vsso:Body ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.ChargingPort"@en .
 
 vsso:BodyRefuelPosition a owl:Class ;
     rdfs:label "BodyRefuelPosition"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Body ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Location of the fuel cap or charge port"@en ;
     vsso-core:vssFacetedClassification "Vehicle.Body.RefuelPosition"@en .
-
-vsso:BodyTrunk a owl:Class ;
-    rdfs:label "BodyTrunk"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Body ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Trunk status"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Body.Trunk"@en .
 
 vsso:BrakeBrakesWorn a vsso-core:ObservableVehicleProperty ;
     rdfs:label "BrakeBrakesWorn"@en ;
     skos:definition "Brake pad wear status. True = Worn. False = Not Worn."@en ;
+    vsso-core:belongsToVehicleComponent vsso:WheelBrake ;
     vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle.Wheel.Brake.BrakesWorn"@en .
 
 vsso:BrakeFluidLevel a vsso-core:ObservableVehicleProperty ;
     rdfs:label "BrakeFluidLevel"@en ;
     skos:definition "Brake fluid level as percent. 0 = Empty. 100 = Full."@en ;
+    vsso-core:belongsToVehicleComponent vsso:WheelBrake ;
     vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle.Wheel.Brake.FluidLevel"@en .
 
 vsso:BrakeFluidLevelLow a vsso-core:ObservableVehicleProperty ;
     rdfs:label "BrakeFluidLevelLow"@en ;
     skos:definition "Brake fluid level status. True = Brake fluid level low. False = Brake fluid level OK."@en ;
+    vsso-core:belongsToVehicleComponent vsso:WheelBrake ;
     vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle.Wheel.Brake.FluidLevelLow"@en .
 
 vsso:BrakePadWear a vsso-core:ObservableVehicleProperty ;
     rdfs:label "BrakePadWear"@en ;
     skos:definition "Brake pad wear as percent. 0 = No Wear. 100 = Worn."@en ;
+    vsso-core:belongsToVehicleComponent vsso:WheelBrake ;
     vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle.Wheel.Brake.PadWear"@en .
 
 vsso:BrakePedalPosition a vsso-core:ObservableVehicleProperty ;
     rdfs:label "BrakePedalPosition"@en ;
     skos:definition "Brake pedal position as percent. 0 = Not depressed. 100 = Fully depressed."@en ;
+    vsso-core:belongsToVehicleComponent vsso:ChassisBrake ;
     vsso-core:vssFacetedClassification "Vehicle.Chassis.Brake.PedalPosition"@en .
-
-vsso:CabinConvertible a owl:Class ;
-    rdfs:label "CabinConvertible"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Cabin ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Convertible roof"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Cabin.Convertible"@en .
 
 vsso:CabinDoorCount a owl:Class ;
     rdfs:label "CabinDoorCount"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Cabin ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Number of doors in vehicle"@en ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.DoorCount"@en .
 
 vsso:CabinDriverPosition a owl:Class ;
     rdfs:label "CabinDriverPosition"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Cabin ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "The position of the driver seat in row 1."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.DriverPosition"@en .
 
-vsso:CabinRearShade a owl:Class ;
-    rdfs:label "CabinRearShade"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Cabin ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Rear window shade."@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Cabin.RearShade"@en .
-
-vsso:CabinRearviewMirror a owl:Class ;
-    rdfs:label "CabinRearviewMirror"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Cabin ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Rearview mirror"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Cabin.RearviewMirror"@en .
-
 vsso:CabinSeatPosCount a owl:Class ;
     rdfs:label "CabinSeatPosCount"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Cabin ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Number of seats across each row from the front to the rear"@en ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.SeatPosCount"@en .
 
 vsso:CabinSeatRowCount a owl:Class ;
     rdfs:label "CabinSeatRowCount"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Cabin ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Number of seat rows in vehicle"@en ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.SeatRowCount"@en .
-
-vsso:CatalystBank1 a owl:Class ;
-    rdfs:label "CatalystBank1"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBDCatalyst ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Catalyst bank 1 signals"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.OBD.Catalyst.Bank1"@en .
-
-vsso:CatalystBank2 a owl:Class ;
-    rdfs:label "CatalystBank2"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBDCatalyst ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Catalyst bank 2 signals"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.OBD.Catalyst.Bank2"@en .
 
 vsso:ChargingChargeCurrent a vsso-core:ObservableVehicleProperty ;
     rdfs:label "ChargingChargeCurrent"@en ;
     skos:definition "Current charging current."@en ;
+    vsso-core:belongsToVehicleComponent vsso:BatteryCharging ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Charging.ChargeCurrent"@en .
 
 vsso:ChargingChargeLimit a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "ChargingChargeLimit"@en ;
     skos:definition "Maximum charge level for battery, can potentially be set manually."@en ;
+    vsso-core:belongsToVehicleComponent vsso:BatteryCharging ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Charging.ChargeLimit"@en .
 
 vsso:ChargingChargePlugStatus a vsso-core:ObservableVehicleProperty ;
     rdfs:label "ChargingChargePlugStatus"@en ;
     skos:definition "Signal indicating if charge plug is connected or not."@en ;
+    vsso-core:belongsToVehicleComponent vsso:BatteryCharging ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Charging.ChargePlugStatus"@en .
 
 vsso:ChargingChargePlugType a owl:Class ;
     rdfs:label "ChargingChargePlugType"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BatteryCharging ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Type of charge plug available on the vehicle (CSS includes Type2)."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Charging.ChargePlugType"@en .
 
@@ -512,35 +327,37 @@ vsso:ChargingChargePortFlap a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "ChargingChargePortFlap"@en ;
     skos:definition "Signal indicating if charge port cover is open or closed, can potentially be controlled manually."@en ;
+    vsso-core:belongsToVehicleComponent vsso:BatteryCharging ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Charging.ChargePortFlap"@en .
 
 vsso:ChargingChargeRate a vsso-core:ObservableVehicleProperty ;
     rdfs:label "ChargingChargeRate"@en ;
     skos:definition "Current charging rate, as in kilometers of range added per hour."@en ;
+    vsso-core:belongsToVehicleComponent vsso:BatteryCharging ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Charging.ChargeRate"@en .
 
 vsso:ChargingChargeVoltage a vsso-core:ObservableVehicleProperty ;
     rdfs:label "ChargingChargeVoltage"@en ;
     skos:definition "Current charging voltage."@en ;
+    vsso-core:belongsToVehicleComponent vsso:BatteryCharging ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Charging.ChargeVoltage"@en .
 
 vsso:ChargingMaximumChargingCurrent a vsso-core:ObservableVehicleProperty ;
     rdfs:label "ChargingMaximumChargingCurrent"@en ;
     skos:definition "Maximum charging current that can be accepted by the system."@en ;
+    vsso-core:belongsToVehicleComponent vsso:BatteryCharging ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Charging.MaximumChargingCurrent"@en .
 
 vsso:ChargingMode a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "ChargingMode"@en ;
     skos:definition "Control of the charge process - manually initiated (plug-in event, companion app, etc), timer-based or grid-controlled (eg ISO 15118)."@en ;
+    vsso-core:belongsToVehicleComponent vsso:BatteryCharging ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Charging.Mode"@en .
 
 vsso:ChargingPortType a owl:Class ;
     rdfs:label "ChargingPortType"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BodyChargingPort ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Indicates the primary charging type fitted to the vehicle"@en ;
     vsso-core:vssFacetedClassification "Vehicle.Body.ChargingPort.Type"@en .
 
@@ -548,844 +365,708 @@ vsso:ChargingStartStopCharging a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "ChargingStartStopCharging"@en ;
     skos:definition "Start or stop the charging process."@en ;
+    vsso-core:belongsToVehicleComponent vsso:BatteryCharging ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Charging.StartStopCharging"@en .
 
 vsso:ChargingStatus a vsso-core:ObservableVehicleProperty ;
     rdfs:label "ChargingStatus"@en ;
     skos:definition "State of charging process."@en ;
+    vsso-core:belongsToVehicleComponent vsso:BatteryCharging ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Charging.Status"@en .
 
 vsso:ChargingTimeToComplete a vsso-core:ObservableVehicleProperty ;
     rdfs:label "ChargingTimeToComplete"@en ;
     skos:definition "The time needed to complete the current charging process to the set charge limit. 0 if charging is complete, negative number if no charging process is active."@en ;
+    vsso-core:belongsToVehicleComponent vsso:BatteryCharging ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Charging.TimeToComplete"@en .
-
-vsso:ChargingTimer a owl:Class ;
-    rdfs:label "ChargingTimer"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BatteryCharging ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Properties related to timing of battery charging sessions."@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Charging.Timer"@en .
-
-vsso:ChassisAccelerator a owl:Class ;
-    rdfs:label "ChassisAccelerator"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Chassis ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Accelerator signals"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Chassis.Accelerator"@en .
 
 vsso:ChassisAxleCount a owl:Class ;
     rdfs:label "ChassisAxleCount"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Chassis ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Number of axles on the vehicle"@en ;
     vsso-core:vssFacetedClassification "Vehicle.Chassis.AxleCount"@en .
 
-vsso:ChassisBrake a owl:Class ;
-    rdfs:label "ChassisBrake"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Chassis ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Brake system signals"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Chassis.Brake"@en .
-
 vsso:ChassisCurbWeight a owl:Class ;
     rdfs:label "ChassisCurbWeight"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Chassis ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Vehicle curb weight, in kg, including all liquids and full tank of fuel, but no cargo or passengers."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Chassis.CurbWeight"@en .
 
 vsso:ChassisGrossWeight a owl:Class ;
     rdfs:label "ChassisGrossWeight"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Chassis ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Curb weight of vehicle, including all liquids and full tank of fuel and full load of cargo and passengers."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Chassis.GrossWeight"@en .
 
 vsso:ChassisHeight a owl:Class ;
     rdfs:label "ChassisHeight"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Chassis ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Overall vehicle height, in mm."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Chassis.Height"@en .
 
 vsso:ChassisLength a owl:Class ;
     rdfs:label "ChassisLength"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Chassis ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Overall vehicle length, in mm."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Chassis.Length"@en .
 
-vsso:ChassisParkingBrake a owl:Class ;
-    rdfs:label "ChassisParkingBrake"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Chassis ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Parking brake signals"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Chassis.ParkingBrake"@en .
-
 vsso:ChassisTowWeight a owl:Class ;
     rdfs:label "ChassisTowWeight"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Chassis ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Maximum weight, in kilos, of trailer."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Chassis.TowWeight"@en .
 
 vsso:ChassisTrack a owl:Class ;
     rdfs:label "ChassisTrack"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Chassis ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Overall wheel tracking, in mm."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Chassis.Track"@en .
-
-vsso:ChassisTrailer a owl:Class ;
-    rdfs:label "ChassisTrailer"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Chassis ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Trailer signals"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Chassis.Trailer"@en .
 
 vsso:ChassisTrailerConnected a vsso-core:ObservableVehicleProperty ;
     rdfs:label "ChassisTrailerConnected"@en ;
     skos:definition "Signal indicating if trailer is connected or not."@en ;
+    vsso-core:belongsToVehicleComponent vsso:ChassisTrailer ;
     vsso-core:vssFacetedClassification "Vehicle.Chassis.Trailer.Connected"@en .
 
 vsso:ChassisWheelbase a owl:Class ;
     rdfs:label "ChassisWheelbase"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Chassis ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Overall wheel base, in mm."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Chassis.Wheelbase"@en .
 
 vsso:ChassisWidth a owl:Class ;
     rdfs:label "ChassisWidth"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Chassis ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Overall vehicle width, in mm."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Chassis.Width"@en .
 
 vsso:CombustionEngineAspirationType a owl:Class ;
     rdfs:label "CombustionEngineAspirationType"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Type of aspiration (natural, turbocharger, supercharger etc)."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.AspirationType"@en .
 
 vsso:CombustionEngineBore a owl:Class ;
     rdfs:label "CombustionEngineBore"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Bore in millimetres."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.Bore"@en .
 
 vsso:CombustionEngineCompressionRatio a owl:Class ;
     rdfs:label "CombustionEngineCompressionRatio"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Engine compression ratio."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.CompressionRatio"@en .
 
 vsso:CombustionEngineConfiguration a owl:Class ;
     rdfs:label "CombustionEngineConfiguration"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Engine configuration."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.Configuration"@en .
 
-vsso:CombustionEngineDieselParticulateFilter a owl:Class ;
-    rdfs:label "CombustionEngineDieselParticulateFilter"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Diesel Particulate Filter signals"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.DieselParticulateFilter"@en .
-
 vsso:CombustionEngineDisplacement a owl:Class ;
     rdfs:label "CombustionEngineDisplacement"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Displacement in cubic centimetres."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.Displacement"@en .
 
-vsso:CombustionEngineEngine a owl:Class ;
-    rdfs:label "CombustionEngineEngine"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Engine signals"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.Engine"@en .
-
 vsso:CombustionEngineEngineCoolantCapacity a owl:Class ;
     rdfs:label "CombustionEngineEngineCoolantCapacity"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Engine coolant capacity in liters."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.EngineCoolantCapacity"@en .
 
 vsso:CombustionEngineEngineOilCapacity a owl:Class ;
     rdfs:label "CombustionEngineEngineOilCapacity"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Engine oil capacity in liters."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.EngineOilCapacity"@en .
 
 vsso:CombustionEngineEngineOilLevel a owl:Class ;
     rdfs:label "CombustionEngineEngineOilLevel"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Vehicle oil level."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.EngineOilLevel"@en .
 
 vsso:CombustionEngineFuelType a owl:Class ;
     rdfs:label "CombustionEngineFuelType"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Type of fuel that the engine runs on."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.FuelType"@en .
 
 vsso:CombustionEngineMaxPower a owl:Class ;
     rdfs:label "CombustionEngineMaxPower"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Peak power, in kilowatts, that engine can generate."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.MaxPower"@en .
 
 vsso:CombustionEngineMaxTorque a owl:Class ;
     rdfs:label "CombustionEngineMaxTorque"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Peak power, in newton meter, that the engine can generate."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.MaxTorque"@en .
 
 vsso:CombustionEngineNumberOfCylinders a owl:Class ;
     rdfs:label "CombustionEngineNumberOfCylinders"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Number of cylinders."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.NumberOfCylinders"@en .
 
 vsso:CombustionEngineNumberOfValvesPerCylinder a owl:Class ;
     rdfs:label "CombustionEngineNumberOfValvesPerCylinder"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Number of valves per cylinder."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.NumberOfValvesPerCylinder"@en .
 
 vsso:CombustionEngineOilLifeRemaining a vsso-core:ObservableVehicleProperty ;
     rdfs:label "CombustionEngineOilLifeRemaining"@en ;
     skos:definition "Remaining engine oil life in seconds. Negative values can be used to indicate that lifetime has been exceeded."@en ;
+    vsso-core:belongsToVehicleComponent vsso:PowertrainCombustionEngine ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.OilLifeRemaining"@en .
 
 vsso:CombustionEngineStrokeLength a owl:Class ;
     rdfs:label "CombustionEngineStrokeLength"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainCombustionEngine ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Stroke length in millimetres."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.StrokeLength"@en .
 
 vsso:ConvertibleStatus a vsso-core:ObservableVehicleProperty ;
     rdfs:label "ConvertibleStatus"@en ;
     skos:definition "Roof status on convertible vehicles"@en ;
+    vsso-core:belongsToVehicleComponent vsso:CabinConvertible ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Convertible.Status"@en .
 
 vsso:CruiseControlError a vsso-core:ObservableVehicleProperty ;
     rdfs:label "CruiseControlError"@en ;
     skos:definition "Indicates if cruise control system incurred and error condition. True = Error. False = NoError."@en ;
+    vsso-core:belongsToVehicleComponent vsso:ADASCruiseControl ;
     vsso-core:vssFacetedClassification "Vehicle.ADAS.CruiseControl.Error"@en .
 
 vsso:CruiseControlIsActive a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "CruiseControlIsActive"@en ;
     skos:definition "Indicates if cruise control system is enabled. True = Enabled. False = Disabled."@en ;
+    vsso-core:belongsToVehicleComponent vsso:ADASCruiseControl ;
     vsso-core:vssFacetedClassification "Vehicle.ADAS.CruiseControl.IsActive"@en .
 
 vsso:CruiseControlSpeedSet a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "CruiseControlSpeedSet"@en ;
     skos:definition "Set cruise control speed in kilometers per hour"@en ;
+    vsso-core:belongsToVehicleComponent vsso:ADASCruiseControl ;
     vsso-core:vssFacetedClassification "Vehicle.ADAS.CruiseControl.SpeedSet"@en .
 
 vsso:CurbWeight a owl:Class ;
     rdfs:label "CurbWeight"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Vehicle curb weight, including all liquids and full tank of fuel, but no cargo or passengers."@en ;
     vsso-core:vssFacetedClassification "Vehicle.CurbWeight"@en .
-
-vsso:CurrentLocation a owl:Class ;
-    rdfs:label "CurrentLocation"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "The current latitude and longitude of the vehicle."@en ;
-    vsso-core:vssFacetedClassification "Vehicle.CurrentLocation"@en .
 
 vsso:CurrentLocationAccuracy a vsso-core:ObservableVehicleProperty ;
     rdfs:label "CurrentLocationAccuracy"@en ;
     skos:definition "Accuracy level of the latitude and longitude coordinates."@en ;
+    vsso-core:belongsToVehicleComponent vsso:CurrentLocation ;
     vsso-core:vssFacetedClassification "Vehicle.CurrentLocation.Accuracy"@en .
 
 vsso:CurrentLocationAltitude a vsso-core:ObservableVehicleProperty ;
     rdfs:label "CurrentLocationAltitude"@en ;
     skos:definition "Current elevation of the position."@en ;
+    vsso-core:belongsToVehicleComponent vsso:CurrentLocation ;
     vsso-core:vssFacetedClassification "Vehicle.CurrentLocation.Altitude"@en .
 
 vsso:CurrentLocationHeading a vsso-core:ObservableVehicleProperty ;
     rdfs:label "CurrentLocationHeading"@en ;
     skos:definition "Current magnetic compass heading."@en ;
+    vsso-core:belongsToVehicleComponent vsso:CurrentLocation ;
     vsso-core:vssFacetedClassification "Vehicle.CurrentLocation.Heading"@en .
 
 vsso:CurrentLocationLatitude a vsso-core:ObservableVehicleProperty ;
     rdfs:label "CurrentLocationLatitude"@en ;
     skos:definition "Current latitude of vehicle."@en ;
+    vsso-core:belongsToVehicleComponent vsso:CurrentLocation ;
     vsso-core:vssFacetedClassification "Vehicle.CurrentLocation.Latitude"@en .
 
 vsso:CurrentLocationLongitude a vsso-core:ObservableVehicleProperty ;
     rdfs:label "CurrentLocationLongitude"@en ;
     skos:definition "Current longitude of vehicle."@en ;
+    vsso-core:belongsToVehicleComponent vsso:CurrentLocation ;
     vsso-core:vssFacetedClassification "Vehicle.CurrentLocation.Longitude"@en .
 
 vsso:CurrentLocationSpeed a vsso-core:ObservableVehicleProperty ;
     rdfs:label "CurrentLocationSpeed"@en ;
     skos:definition "Vehicle speed, as sensed by the GPS receiver."@en ;
+    vsso-core:belongsToVehicleComponent vsso:NavigationCurrentLocation ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Navigation.CurrentLocation.Speed"@en .
 
 vsso:CurrentOverallWeight a vsso-core:ObservableVehicleProperty ;
     rdfs:label "CurrentOverallWeight"@en ;
     skos:definition "Current overall Vehicle weight. Including passengers, cargo and other load inside the car."@en ;
+    vsso-core:belongsToVehicleComponent vsso:Vehicle ;
     vsso-core:vssFacetedClassification "Vehicle.CurrentOverallWeight"@en .
 
 vsso:CushionBackward a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "CushionBackward"@en ;
     skos:definition "Seat cushion backward/shorten switch engaged (SingleSeat.Cushion.Length)"@en ;
+    vsso-core:belongsToVehicleComponent vsso:SwitchCushion ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Cushion.Backward"@en .
 
 vsso:CushionDown a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "CushionDown"@en ;
     skos:definition "Seat cushion down switch engaged (SingleSeat.Cushion.Height)"@en ;
+    vsso-core:belongsToVehicleComponent vsso:SwitchCushion ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Cushion.Down"@en .
 
 vsso:CushionForward a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "CushionForward"@en ;
     skos:definition "Seat cushion forward/lengthen switch engaged (SingleSeat.Cushion.Length)"@en ;
+    vsso-core:belongsToVehicleComponent vsso:SwitchCushion ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Cushion.Forward"@en .
 
 vsso:CushionHeight a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "CushionHeight"@en ;
     skos:definition "Height of the seat cushion (leg support), relative to seat. 0 = Lowermost. 500 = Uppermost."@en ;
+    vsso-core:belongsToVehicleComponent vsso:SeatCushion ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Cushion.Height"@en .
 
 vsso:CushionLength a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "CushionLength"@en ;
     skos:definition "Forward length of cushion (leg support), relative to seat. 0 = Rearmost. 500 = Forwardmost."@en ;
+    vsso-core:belongsToVehicleComponent vsso:SeatCushion ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Cushion.Length"@en .
 
 vsso:CushionUp a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "CushionUp"@en ;
     skos:definition "Seat cushion up switch engaged (SingleSeat.Cushion.Height)"@en ;
+    vsso-core:belongsToVehicleComponent vsso:SwitchCushion ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Cushion.Up"@en .
 
 vsso:DestinationSetLatitude a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "DestinationSetLatitude"@en ;
     skos:definition "Latitude of destination"@en ;
+    vsso-core:belongsToVehicleComponent vsso:NavigationDestinationSet ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Navigation.DestinationSet.Latitude"@en .
 
 vsso:DestinationSetLongitude a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "DestinationSetLongitude"@en ;
     skos:definition "Longitude of destination"@en ;
+    vsso-core:belongsToVehicleComponent vsso:NavigationDestinationSet ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Navigation.DestinationSet.Longitude"@en .
 
 vsso:DieselParticulateFilterDeltaPressure a vsso-core:ObservableVehicleProperty ;
     rdfs:label "DieselParticulateFilterDeltaPressure"@en ;
     skos:definition "Delta Pressure of Diesel Particulate Filter."@en ;
+    vsso-core:belongsToVehicleComponent vsso:CombustionEngineDieselParticulateFilter ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.DieselParticulateFilter.DeltaPressure"@en .
 
 vsso:DieselParticulateFilterInletTemperature a vsso-core:ObservableVehicleProperty ;
     rdfs:label "DieselParticulateFilterInletTemperature"@en ;
     skos:definition "Inlet temperature of Diesel Particulate Filter."@en ;
+    vsso-core:belongsToVehicleComponent vsso:CombustionEngineDieselParticulateFilter ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.DieselParticulateFilter.InletTemperature"@en .
 
 vsso:DieselParticulateFilterOutletTemperature a vsso-core:ObservableVehicleProperty ;
     rdfs:label "DieselParticulateFilterOutletTemperature"@en ;
     skos:definition "Outlet temperature of Diesel Particulate Filter."@en ;
+    vsso-core:belongsToVehicleComponent vsso:CombustionEngineDieselParticulateFilter ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.DieselParticulateFilter.OutletTemperature"@en .
 
 vsso:DoorIsChildLockActive a vsso-core:ObservableVehicleProperty ;
     rdfs:label "DoorIsChildLockActive"@en ;
     skos:definition "Is door child lock engaged. True = Engaged. False = Disengaged."@en ;
+    vsso-core:belongsToVehicleComponent vsso:CabinDoor ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Door.IsChildLockActive"@en .
 
 vsso:DoorIsLocked a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "DoorIsLocked"@en ;
     skos:definition "Is door locked or unlocked. True = Locked. False = Unlocked."@en ;
+    vsso-core:belongsToVehicleComponent vsso:CabinDoor ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Door.IsLocked"@en .
 
 vsso:DoorIsOpen a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "DoorIsOpen"@en ;
     skos:definition "Is door open or closed"@en ;
+    vsso-core:belongsToVehicleComponent vsso:CabinDoor ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Door.IsOpen"@en .
-
-vsso:DoorShade a owl:Class ;
-    rdfs:label "DoorShade"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinDoor ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Side window shade"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Cabin.Door.Shade"@en .
 
 vsso:DoorShadePosition a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "DoorShadePosition"@en ;
     skos:definition "Position of window blind. 0 = Fully retracted. 100 = Fully deployed."@en ;
+    vsso-core:belongsToVehicleComponent vsso:DoorShade ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Door.Shade.Position"@en .
 
 vsso:DoorShadeSwitch a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "DoorShadeSwitch"@en ;
     skos:definition "Switch controlling sliding action such as window, sunroof, or blind."@en ;
+    vsso-core:belongsToVehicleComponent vsso:DoorShade ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Door.Shade.Switch"@en .
-
-vsso:DoorWindow a owl:Class ;
-    rdfs:label "DoorWindow"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinDoor ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Door window status"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Cabin.Door.Window"@en .
 
 vsso:DriveCycleStatusDTCCount a vsso-core:ObservableVehicleProperty ;
     rdfs:label "DriveCycleStatusDTCCount"@en ;
     skos:definition "Number of sensor Trouble Codes (DTC)"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBDDriveCycleStatus ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.DriveCycleStatus.DTCCount"@en .
 
 vsso:DriveCycleStatusIgnitionType a vsso-core:ObservableVehicleProperty ;
     rdfs:label "DriveCycleStatusIgnitionType"@en ;
     skos:definition "Type of the ignition for ICE - spark = spark plug ignition, compression = self-igniting (Diesel engines)"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBDDriveCycleStatus ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.DriveCycleStatus.IgnitionType"@en .
 
 vsso:DriveCycleStatusMIL a vsso-core:ObservableVehicleProperty ;
     rdfs:label "DriveCycleStatusMIL"@en ;
     skos:definition "Malfunction Indicator Light (MIL) - False = Off, True = On"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBDDriveCycleStatus ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.DriveCycleStatus.MIL"@en .
 
 vsso:DriveTime a vsso-core:ObservableVehicleProperty ;
     rdfs:label "DriveTime"@en ;
     skos:definition "Accumulated drive time in seconds."@en ;
+    vsso-core:belongsToVehicleComponent vsso:Vehicle ;
     vsso-core:vssFacetedClassification "Vehicle.DriveTime"@en .
 
 vsso:DriverAttentiveProbability a vsso-core:ObservableVehicleProperty ;
     rdfs:label "DriverAttentiveProbability"@en ;
     skos:definition "Probability of attentiveness of the driver."@en ;
+    vsso-core:belongsToVehicleComponent vsso:Driver ;
     vsso-core:vssFacetedClassification "Vehicle.Driver.AttentiveProbability"@en .
 
 vsso:DriverDistractionLevel a vsso-core:ObservableVehicleProperty ;
     rdfs:label "DriverDistractionLevel"@en ;
     skos:definition "Distraction level of the driver will be the level how much the driver is distracted, by multiple factors. E.g. Driving situation, acustical or optical signales inside the cockpit, phone calls"@en ;
+    vsso-core:belongsToVehicleComponent vsso:Driver ;
     vsso-core:vssFacetedClassification "Vehicle.Driver.DistractionLevel"@en .
 
 vsso:DriverEyesOnRoad a vsso-core:ObservableVehicleProperty ;
     rdfs:label "DriverEyesOnRoad"@en ;
     skos:definition "Has driver the eyes on road or not?"@en ;
+    vsso-core:belongsToVehicleComponent vsso:Driver ;
     vsso-core:vssFacetedClassification "Vehicle.Driver.EyesOnRoad"@en .
 
 vsso:DriverFatigueLevel a vsso-core:ObservableVehicleProperty ;
     rdfs:label "DriverFatigueLevel"@en ;
     skos:definition "Fatigueness level of driver. Evaluated by multiple factors like trip time, behaviour of steering, eye status."@en ;
+    vsso-core:belongsToVehicleComponent vsso:Driver ;
     vsso-core:vssFacetedClassification "Vehicle.Driver.FatigueLevel"@en .
 
 vsso:DriverHeartRate a vsso-core:ObservableVehicleProperty ;
     rdfs:label "DriverHeartRate"@en ;
     skos:definition "Heart rate of the driver."@en ;
+    vsso-core:belongsToVehicleComponent vsso:Driver ;
     vsso-core:vssFacetedClassification "Vehicle.Driver.HeartRate"@en .
-
-vsso:DriverIdentifier a owl:Class ;
-    rdfs:label "DriverIdentifier"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Driver ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Identifier attributes based on OAuth 2.0."@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Driver.Identifier"@en .
 
 vsso:DriverIdentifierIssuer a vsso-core:ObservableVehicleProperty ;
     rdfs:label "DriverIdentifierIssuer"@en ;
     skos:definition "Unique Issuer for the authentification of the occupant. E.g. https://accounts.funcorp.com"@en ;
+    vsso-core:belongsToVehicleComponent vsso:DriverIdentifier ;
     vsso-core:vssFacetedClassification "Vehicle.Driver.Identifier.Issuer"@en .
 
 vsso:DriverIdentifierSubject a vsso-core:ObservableVehicleProperty ;
     rdfs:label "DriverIdentifierSubject"@en ;
     skos:definition "Subject for the authentification of the occupant. E.g. UserID 7331677"@en ;
+    vsso-core:belongsToVehicleComponent vsso:DriverIdentifier ;
     vsso-core:vssFacetedClassification "Vehicle.Driver.Identifier.Subject"@en .
 
 vsso:ESCError a vsso-core:ObservableVehicleProperty ;
     rdfs:label "ESCError"@en ;
     skos:definition "Indicates if ESC incurred an error condition. True = Error. False = No Error."@en ;
+    vsso-core:belongsToVehicleComponent vsso:ADASESC ;
     vsso-core:vssFacetedClassification "Vehicle.ADAS.ESC.Error"@en .
 
 vsso:ESCIsActive a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "ESCIsActive"@en ;
     skos:definition "Indicates if ECS is enabled. True = Enabled. False = Disabled."@en ;
+    vsso-core:belongsToVehicleComponent vsso:ADASESC ;
     vsso-core:vssFacetedClassification "Vehicle.ADAS.ESC.IsActive"@en .
 
 vsso:ESCIsEngaged a vsso-core:ObservableVehicleProperty ;
     rdfs:label "ESCIsEngaged"@en ;
     skos:definition "Indicates if ESC is currently regulating vehicle stability. True = Engaged. False = Not Engaged."@en ;
+    vsso-core:belongsToVehicleComponent vsso:ADASESC ;
     vsso-core:vssFacetedClassification "Vehicle.ADAS.ESC.IsEngaged"@en .
 
 vsso:ElectricMotorMaxPower a owl:Class ;
     rdfs:label "ElectricMotorMaxPower"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainElectricMotor ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Peak power, in kilowatts, that motor(s) can generate."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.ElectricMotor.MaxPower"@en .
 
 vsso:ElectricMotorMaxRegenPower a owl:Class ;
     rdfs:label "ElectricMotorMaxRegenPower"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainElectricMotor ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Peak regen/brake power, in kilowatts, that motor(s) can generate."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.ElectricMotor.MaxRegenPower"@en .
 
 vsso:ElectricMotorMaxRegenTorque a owl:Class ;
     rdfs:label "ElectricMotorMaxRegenTorque"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainElectricMotor ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Peak regen/brake torque, in newton meter, that the motor(s) can generate."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.ElectricMotor.MaxRegenTorque"@en .
 
 vsso:ElectricMotorMaxTorque a owl:Class ;
     rdfs:label "ElectricMotorMaxTorque"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainElectricMotor ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Peak power, in newton meter, that the motor(s) can generate."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.ElectricMotor.MaxTorque"@en .
-
-vsso:ElectricMotorMotor a owl:Class ;
-    rdfs:label "ElectricMotorMotor"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainElectricMotor ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "motor signals"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Powertrain.ElectricMotor.Motor"@en .
 
 vsso:EngineECT a vsso-core:ObservableVehicleProperty ;
     rdfs:label "EngineECT"@en ;
     skos:definition "Engine coolant temperature."@en ;
+    vsso-core:belongsToVehicleComponent vsso:CombustionEngineEngine ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.Engine.ECT"@en .
 
 vsso:EngineEOP a vsso-core:ObservableVehicleProperty ;
     rdfs:label "EngineEOP"@en ;
     skos:definition "Engine oil pressure."@en ;
+    vsso-core:belongsToVehicleComponent vsso:CombustionEngineEngine ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.Engine.EOP"@en .
 
 vsso:EngineEOT a vsso-core:ObservableVehicleProperty ;
     rdfs:label "EngineEOT"@en ;
     skos:definition "Engine oil temperature."@en ;
+    vsso-core:belongsToVehicleComponent vsso:CombustionEngineEngine ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.Engine.EOT"@en .
 
 vsso:EngineMAF a vsso-core:ObservableVehicleProperty ;
     rdfs:label "EngineMAF"@en ;
     skos:definition "Grams of air drawn into engine per second."@en ;
+    vsso-core:belongsToVehicleComponent vsso:CombustionEngineEngine ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.Engine.MAF"@en .
 
 vsso:EngineMAP a vsso-core:ObservableVehicleProperty ;
     rdfs:label "EngineMAP"@en ;
     skos:definition "Manifold air pressure possibly boosted using forced induction."@en ;
+    vsso-core:belongsToVehicleComponent vsso:CombustionEngineEngine ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.Engine.MAP"@en .
 
 vsso:EnginePower a vsso-core:ObservableVehicleProperty ;
     rdfs:label "EnginePower"@en ;
     skos:definition "Current engine power output."@en ;
+    vsso-core:belongsToVehicleComponent vsso:CombustionEngineEngine ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.Engine.Power"@en .
 
 vsso:EngineSpeed a vsso-core:ObservableVehicleProperty ;
     rdfs:label "EngineSpeed"@en ;
     skos:definition "Engine speed measured as rotations per minute."@en ;
+    vsso-core:belongsToVehicleComponent vsso:CombustionEngineEngine ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.Engine.Speed"@en .
 
 vsso:EngineTPS a vsso-core:ObservableVehicleProperty ;
     rdfs:label "EngineTPS"@en ;
     skos:definition "Current throttle position."@en ;
+    vsso-core:belongsToVehicleComponent vsso:CombustionEngineEngine ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.Engine.TPS"@en .
 
 vsso:EngineTorque a vsso-core:ObservableVehicleProperty ;
     rdfs:label "EngineTorque"@en ;
     skos:definition "Current engine torque."@en ;
+    vsso-core:belongsToVehicleComponent vsso:CombustionEngineEngine ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.Engine.Torque"@en .
 
 vsso:FuelSystemAverageConsumption a vsso-core:ObservableVehicleProperty ;
     rdfs:label "FuelSystemAverageConsumption"@en ;
     skos:definition "Average consumption in liters per 100 km."@en ;
+    vsso-core:belongsToVehicleComponent vsso:PowertrainFuelSystem ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.FuelSystem.AverageConsumption"@en .
 
 vsso:FuelSystemConsumptionSinceStart a vsso-core:ObservableVehicleProperty ;
     rdfs:label "FuelSystemConsumptionSinceStart"@en ;
     skos:definition "Fuel amount in liters consumed since start of current trip."@en ;
+    vsso-core:belongsToVehicleComponent vsso:PowertrainFuelSystem ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.FuelSystem.ConsumptionSinceStart"@en .
 
 vsso:FuelSystemEngineStopStartEnabled a vsso-core:ObservableVehicleProperty ;
     rdfs:label "FuelSystemEngineStopStartEnabled"@en ;
     skos:definition "Indicates whether eco start stop is currently enabled"@en ;
+    vsso-core:belongsToVehicleComponent vsso:PowertrainFuelSystem ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.FuelSystem.EngineStopStartEnabled"@en .
 
 vsso:FuelSystemFuelType a owl:Class ;
     rdfs:label "FuelSystemFuelType"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainFuelSystem ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Defines the fuel type of the vehicle"@en ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.FuelSystem.FuelType"@en .
 
 vsso:FuelSystemHybridType a owl:Class ;
     rdfs:label "FuelSystemHybridType"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainFuelSystem ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Defines the hybrid type of the vehicle"@en ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.FuelSystem.HybridType"@en .
 
 vsso:FuelSystemInstantConsumption a vsso-core:ObservableVehicleProperty ;
     rdfs:label "FuelSystemInstantConsumption"@en ;
     skos:definition "Current consumption in liters per 100 km."@en ;
+    vsso-core:belongsToVehicleComponent vsso:PowertrainFuelSystem ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.FuelSystem.InstantConsumption"@en .
 
 vsso:FuelSystemLevel a vsso-core:ObservableVehicleProperty ;
     rdfs:label "FuelSystemLevel"@en ;
     skos:definition "Level in fuel tank as percent of capacity. 0 = empty. 100 = full."@en ;
+    vsso-core:belongsToVehicleComponent vsso:PowertrainFuelSystem ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.FuelSystem.Level"@en .
 
 vsso:FuelSystemLowFuelLevel a vsso-core:ObservableVehicleProperty ;
     rdfs:label "FuelSystemLowFuelLevel"@en ;
     skos:definition "Indicates that the fuel level is low (e.g. <50km range)"@en ;
+    vsso-core:belongsToVehicleComponent vsso:PowertrainFuelSystem ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.FuelSystem.LowFuelLevel"@en .
 
 vsso:FuelSystemRange a vsso-core:ObservableVehicleProperty ;
     rdfs:label "FuelSystemRange"@en ;
     skos:definition "Remaining range in meters using only liquid fuel."@en ;
+    vsso-core:belongsToVehicleComponent vsso:PowertrainFuelSystem ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.FuelSystem.Range"@en .
 
 vsso:FuelSystemTankCapacity a owl:Class ;
     rdfs:label "FuelSystemTankCapacity"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainFuelSystem ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Capacity of the fuel tank in liters"@en ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.FuelSystem.TankCapacity"@en .
 
 vsso:FuelSystemTimeSinceStart a vsso-core:ObservableVehicleProperty ;
     rdfs:label "FuelSystemTimeSinceStart"@en ;
     skos:definition "Time in seconds elapsed since start of current trip."@en ;
+    vsso-core:belongsToVehicleComponent vsso:PowertrainFuelSystem ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.FuelSystem.TimeSinceStart"@en .
 
 vsso:GrossWeight a owl:Class ;
     rdfs:label "GrossWeight"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Curb weight of vehicle, including all liquids and full tank of fuel and full load of cargo and passengers."@en ;
     vsso-core:vssFacetedClassification "Vehicle.GrossWeight"@en .
 
 vsso:HMICurrentLanguage a vsso-core:ObservableVehicleProperty ;
     rdfs:label "HMICurrentLanguage"@en ;
     skos:definition "ISO 639-1 standard language code for the current HMI"@en ;
+    vsso-core:belongsToVehicleComponent vsso:InfotainmentHMI ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.HMI.CurrentLanguage"@en .
 
 vsso:HMIDateFormat a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "HMIDateFormat"@en ;
     skos:definition "Date format used in the current HMI"@en ;
+    vsso-core:belongsToVehicleComponent vsso:InfotainmentHMI ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.HMI.DateFormat"@en .
 
 vsso:HMIDayNightMode a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "HMIDayNightMode"@en ;
     skos:definition "Current display theme"@en ;
+    vsso-core:belongsToVehicleComponent vsso:InfotainmentHMI ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.HMI.DayNightMode"@en .
 
 vsso:HMIDistanceUnit a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "HMIDistanceUnit"@en ;
     skos:definition "Distance unit used in the current HMI"@en ;
+    vsso-core:belongsToVehicleComponent vsso:InfotainmentHMI ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.HMI.DistanceUnit"@en .
 
 vsso:HMIEVEconomyUnits a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "HMIEVEconomyUnits"@en ;
     skos:definition "EV fuel economy unit used in the current HMI"@en ;
+    vsso-core:belongsToVehicleComponent vsso:InfotainmentHMI ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.HMI.EVEconomyUnits"@en .
 
 vsso:HMIFuelEconomyUnits a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "HMIFuelEconomyUnits"@en ;
     skos:definition "Fuel economy unit used in the current HMI"@en ;
+    vsso-core:belongsToVehicleComponent vsso:InfotainmentHMI ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.HMI.FuelEconomyUnits"@en .
 
 vsso:HMITemperatureUnit a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "HMITemperatureUnit"@en ;
     skos:definition "Temperature unit used in the current HMI"@en ;
+    vsso-core:belongsToVehicleComponent vsso:InfotainmentHMI ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.HMI.TemperatureUnit"@en .
 
 vsso:HMITimeFormat a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "HMITimeFormat"@en ;
     skos:definition "Time format used in the current HMI"@en ;
+    vsso-core:belongsToVehicleComponent vsso:InfotainmentHMI ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.HMI.TimeFormat"@en .
 
 vsso:HVACAmbientAirTemperature a vsso-core:ObservableVehicleProperty ;
     rdfs:label "HVACAmbientAirTemperature"@en ;
     skos:definition "Ambient air temperature inside the vehicle."@en ;
+    vsso-core:belongsToVehicleComponent vsso:CabinHVAC ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.HVAC.AmbientAirTemperature"@en .
 
 vsso:HVACIsAirConditioningActive a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "HVACIsAirConditioningActive"@en ;
     skos:definition "Is Air conditioning active."@en ;
+    vsso-core:belongsToVehicleComponent vsso:CabinHVAC ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.HVAC.IsAirConditioningActive"@en .
 
 vsso:HVACIsFrontDefrosterActive a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "HVACIsFrontDefrosterActive"@en ;
     skos:definition "Is front defroster active."@en ;
+    vsso-core:belongsToVehicleComponent vsso:CabinHVAC ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.HVAC.IsFrontDefrosterActive"@en .
 
 vsso:HVACIsRearDefrosterActive a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "HVACIsRearDefrosterActive"@en ;
     skos:definition "Is rear defroster active."@en ;
+    vsso-core:belongsToVehicleComponent vsso:CabinHVAC ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.HVAC.IsRearDefrosterActive"@en .
 
 vsso:HVACIsRecirculationActive a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "HVACIsRecirculationActive"@en ;
     skos:definition "Is recirculation active."@en ;
+    vsso-core:belongsToVehicleComponent vsso:CabinHVAC ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.HVAC.IsRecirculationActive"@en .
-
-vsso:HVACStation a owl:Class ;
-    rdfs:label "HVACStation"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinHVAC ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "HVAC for single station in the vehicle"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Cabin.HVAC.Station"@en .
 
 vsso:HeadRestraintDown a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "HeadRestraintDown"@en ;
     skos:definition "Head restraint down switch engaged (SingleSeat.HeadRestraint.Height)"@en ;
+    vsso-core:belongsToVehicleComponent vsso:SwitchHeadRestraint ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.HeadRestraint.Down"@en .
 
 vsso:HeadRestraintHeight a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "HeadRestraintHeight"@en ;
     skos:definition "Height of head restraint. 0 = Bottommost. 255 = Uppermost."@en ;
+    vsso-core:belongsToVehicleComponent vsso:SeatHeadRestraint ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.HeadRestraint.Height"@en .
 
 vsso:HeadRestraintUp a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "HeadRestraintUp"@en ;
     skos:definition "Head restraint up switch engaged (SingleSeat.HeadRestraint.Height)"@en ;
+    vsso-core:belongsToVehicleComponent vsso:SwitchHeadRestraint ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.HeadRestraint.Up"@en .
 
 vsso:HeatingStatus a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "HeatingStatus"@en ;
     skos:definition "Windshield heater status. 0 - off, 1 - on"@en ;
+    vsso-core:belongsToVehicleComponent vsso:WindshieldHeating ;
     vsso-core:vssFacetedClassification "Vehicle.Body.Windshield.Heating.Status"@en .
 
 vsso:Height a owl:Class ;
     rdfs:label "Height"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Overall vehicle height."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Height"@en .
 
@@ -1393,254 +1074,264 @@ vsso:HoodIsOpen a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "HoodIsOpen"@en ;
     skos:definition "hood open or closed. True = Open. False = Closed"@en ;
+    vsso-core:belongsToVehicleComponent vsso:BodyHood ;
     vsso-core:vssFacetedClassification "Vehicle.Body.Hood.IsOpen"@en .
 
 vsso:HornIsActive a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "HornIsActive"@en ;
     skos:definition "Horn active or inactive. True = Active. False = Inactive."@en ;
+    vsso-core:belongsToVehicleComponent vsso:BodyHorn ;
     vsso-core:vssFacetedClassification "Vehicle.Body.Horn.IsActive"@en .
 
 vsso:IdentifierIssuer a vsso-core:ObservableVehicleProperty ;
     rdfs:label "IdentifierIssuer"@en ;
     skos:definition "Unique Issuer for the authentification of the occupant. E.g. https://accounts.funcorp.com"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OccupantIdentifier ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Occupant.Identifier.Issuer"@en .
 
 vsso:IdentifierSubject a vsso-core:ObservableVehicleProperty ;
     rdfs:label "IdentifierSubject"@en ;
     skos:definition "Subject for the authentification of the occupant. E.g. UserID 7331677"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OccupantIdentifier ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Occupant.Identifier.Subject"@en .
 
 vsso:IdleTime a vsso-core:ObservableVehicleProperty ;
     rdfs:label "IdleTime"@en ;
     skos:definition "Accumulated idle time in seconds."@en ;
+    vsso-core:belongsToVehicleComponent vsso:Vehicle ;
     vsso-core:vssFacetedClassification "Vehicle.IdleTime"@en .
 
 vsso:IgnitionOffTime a vsso-core:ObservableVehicleProperty ;
     rdfs:label "IgnitionOffTime"@en ;
     skos:definition "Accumulated ignition off time in seconds."@en ;
+    vsso-core:belongsToVehicleComponent vsso:Vehicle ;
     vsso-core:vssFacetedClassification "Vehicle.IgnitionOffTime"@en .
 
 vsso:IgnitionOn a vsso-core:ObservableVehicleProperty ;
     rdfs:label "IgnitionOn"@en ;
     skos:definition "Indicates whether the vehicle ignition is on or off."@en ;
+    vsso-core:belongsToVehicleComponent vsso:Vehicle ;
     vsso-core:vssFacetedClassification "Vehicle.IgnitionOn"@en .
 
 vsso:IgnitionOnTime a vsso-core:ObservableVehicleProperty ;
     rdfs:label "IgnitionOnTime"@en ;
     skos:definition "Accumulated ignition on time in seconds."@en ;
+    vsso-core:belongsToVehicleComponent vsso:Vehicle ;
     vsso-core:vssFacetedClassification "Vehicle.IgnitionOnTime"@en .
-
-vsso:InfotainmentHMI a owl:Class ;
-    rdfs:label "InfotainmentHMI"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinInfotainment ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "HMI related signals"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.HMI"@en .
 
 vsso:IsMoving a vsso-core:ObservableVehicleProperty ;
     rdfs:label "IsMoving"@en ;
     skos:definition "Indicates whether the vehicle is stationary or moving"@en ;
+    vsso-core:belongsToVehicleComponent vsso:Vehicle ;
     vsso-core:vssFacetedClassification "Vehicle.IsMoving"@en .
 
 vsso:LaneDepartureDetectionError a vsso-core:ObservableVehicleProperty ;
     rdfs:label "LaneDepartureDetectionError"@en ;
     skos:definition "Indicates if lane departure system incurred an error condition. True = Error. False = No Error."@en ;
+    vsso-core:belongsToVehicleComponent vsso:ADASLaneDepartureDetection ;
     vsso-core:vssFacetedClassification "Vehicle.ADAS.LaneDepartureDetection.Error"@en .
 
 vsso:LaneDepartureDetectionIsActive a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "LaneDepartureDetectionIsActive"@en ;
     skos:definition "Indicates if lane departure detection system is enabled. True = Enabled. False = Disabled."@en ;
+    vsso-core:belongsToVehicleComponent vsso:ADASLaneDepartureDetection ;
     vsso-core:vssFacetedClassification "Vehicle.ADAS.LaneDepartureDetection.IsActive"@en .
 
 vsso:LaneDepartureDetectionWarning a vsso-core:ObservableVehicleProperty ;
     rdfs:label "LaneDepartureDetectionWarning"@en ;
     skos:definition "Indicates if lane departure detection registered a lane departure"@en ;
+    vsso-core:belongsToVehicleComponent vsso:ADASLaneDepartureDetection ;
     vsso-core:vssFacetedClassification "Vehicle.ADAS.LaneDepartureDetection.Warning"@en .
 
 vsso:Length a owl:Class ;
     rdfs:label "Length"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Overall vehicle length."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Length"@en .
 
 vsso:LightsAmbientLight a vsso-core:ObservableVehicleProperty ;
     rdfs:label "LightsAmbientLight"@en ;
     skos:definition "How much ambient light is detected in cabin. 0 = No ambient light. 100 = Full brightness"@en ;
+    vsso-core:belongsToVehicleComponent vsso:CabinLights ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Lights.AmbientLight"@en .
 
 vsso:LightsIsBackupOn a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "LightsIsBackupOn"@en ;
     skos:definition "Is backup (reverse) light on"@en ;
+    vsso-core:belongsToVehicleComponent vsso:BodyLights ;
     vsso-core:vssFacetedClassification "Vehicle.Body.Lights.IsBackupOn"@en .
 
 vsso:LightsIsBrakeOn a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "LightsIsBrakeOn"@en ;
     skos:definition "Is brake light on"@en ;
+    vsso-core:belongsToVehicleComponent vsso:BodyLights ;
     vsso-core:vssFacetedClassification "Vehicle.Body.Lights.IsBrakeOn"@en .
 
 vsso:LightsIsDomeOn a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "LightsIsDomeOn"@en ;
     skos:definition "Is central dome light light on"@en ;
+    vsso-core:belongsToVehicleComponent vsso:CabinLights ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Lights.IsDomeOn"@en .
 
 vsso:LightsIsFrontFogOn a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "LightsIsFrontFogOn"@en ;
     skos:definition "Is front fog light on"@en ;
+    vsso-core:belongsToVehicleComponent vsso:BodyLights ;
     vsso-core:vssFacetedClassification "Vehicle.Body.Lights.IsFrontFogOn"@en .
 
 vsso:LightsIsGloveBoxOn a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "LightsIsGloveBoxOn"@en ;
     skos:definition "Is glove box light on"@en ;
+    vsso-core:belongsToVehicleComponent vsso:CabinLights ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Lights.IsGloveBoxOn"@en .
 
 vsso:LightsIsHazardOn a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "LightsIsHazardOn"@en ;
     skos:definition "Are hazards on"@en ;
+    vsso-core:belongsToVehicleComponent vsso:BodyLights ;
     vsso-core:vssFacetedClassification "Vehicle.Body.Lights.IsHazardOn"@en .
 
 vsso:LightsIsHighBeamOn a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "LightsIsHighBeamOn"@en ;
     skos:definition "Is high beam on"@en ;
+    vsso-core:belongsToVehicleComponent vsso:BodyLights ;
     vsso-core:vssFacetedClassification "Vehicle.Body.Lights.IsHighBeamOn"@en .
 
 vsso:LightsIsLeftIndicatorOn a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "LightsIsLeftIndicatorOn"@en ;
     skos:definition "Is left indicator flashing"@en ;
+    vsso-core:belongsToVehicleComponent vsso:BodyLights ;
     vsso-core:vssFacetedClassification "Vehicle.Body.Lights.IsLeftIndicatorOn"@en .
 
 vsso:LightsIsLowBeamOn a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "LightsIsLowBeamOn"@en ;
     skos:definition "Is low beam on"@en ;
+    vsso-core:belongsToVehicleComponent vsso:BodyLights ;
     vsso-core:vssFacetedClassification "Vehicle.Body.Lights.IsLowBeamOn"@en .
 
 vsso:LightsIsParkingOn a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "LightsIsParkingOn"@en ;
     skos:definition "Is parking light on"@en ;
+    vsso-core:belongsToVehicleComponent vsso:BodyLights ;
     vsso-core:vssFacetedClassification "Vehicle.Body.Lights.IsParkingOn"@en .
 
 vsso:LightsIsRearFogOn a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "LightsIsRearFogOn"@en ;
     skos:definition "Is rear fog light on"@en ;
+    vsso-core:belongsToVehicleComponent vsso:BodyLights ;
     vsso-core:vssFacetedClassification "Vehicle.Body.Lights.IsRearFogOn"@en .
 
 vsso:LightsIsRightIndicatorOn a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "LightsIsRightIndicatorOn"@en ;
     skos:definition "Is right indicator flashing"@en ;
+    vsso-core:belongsToVehicleComponent vsso:BodyLights ;
     vsso-core:vssFacetedClassification "Vehicle.Body.Lights.IsRightIndicatorOn"@en .
 
 vsso:LightsIsRunningOn a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "LightsIsRunningOn"@en ;
     skos:definition "Are running lights on"@en ;
+    vsso-core:belongsToVehicleComponent vsso:BodyLights ;
     vsso-core:vssFacetedClassification "Vehicle.Body.Lights.IsRunningOn"@en .
 
 vsso:LightsIsTrunkOn a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "LightsIsTrunkOn"@en ;
     skos:definition "Is trunk light light on"@en ;
+    vsso-core:belongsToVehicleComponent vsso:CabinLights ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Lights.IsTrunkOn"@en .
 
 vsso:LightsLightIntensity a vsso-core:ObservableVehicleProperty ;
     rdfs:label "LightsLightIntensity"@en ;
     skos:definition "Intensity of the interior lights. 0 = Off. 100 = Full brightness."@en ;
+    vsso-core:belongsToVehicleComponent vsso:CabinLights ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Lights.LightIntensity"@en .
-
-vsso:LightsSpotlight a owl:Class ;
-    rdfs:label "LightsSpotlight"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinLights ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Spotlight for a specific area in the vehicle."@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Cabin.Lights.Spotlight"@en .
 
 vsso:LowVoltageSystemState a vsso-core:ObservableVehicleProperty ;
     rdfs:label "LowVoltageSystemState"@en ;
     skos:definition "State of the supply voltage of the control units (usually 12V)."@en ;
+    vsso-core:belongsToVehicleComponent vsso:Vehicle ;
     vsso-core:vssFacetedClassification "Vehicle.LowVoltageSystemState"@en .
 
 vsso:LumbarDeflate a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "LumbarDeflate"@en ;
     skos:definition "Lumbar deflation switch engaged (SingleSeat.Lumbar.Inflation)"@en ;
+    vsso-core:belongsToVehicleComponent vsso:SwitchLumbar ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Lumbar.Deflate"@en .
 
 vsso:LumbarDown a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "LumbarDown"@en ;
     skos:definition "Lumbar down switch engaged (SingleSeat.Lumbar.Height)"@en ;
+    vsso-core:belongsToVehicleComponent vsso:SwitchLumbar ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Lumbar.Down"@en .
 
 vsso:LumbarHeight a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "LumbarHeight"@en ;
     skos:definition "Lumbar support position. 0 = Lowermost. 255 = Uppermost."@en ;
+    vsso-core:belongsToVehicleComponent vsso:SeatLumbar ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Lumbar.Height"@en .
 
 vsso:LumbarInflate a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "LumbarInflate"@en ;
     skos:definition "Lumbar inflation switch engaged (SingleSeat.Lumbar.Inflation)"@en ;
+    vsso-core:belongsToVehicleComponent vsso:SwitchLumbar ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Lumbar.Inflate"@en .
 
 vsso:LumbarInflation a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "LumbarInflation"@en ;
     skos:definition "Lumbar support inflation. 0 = Fully deflated. 255 = Fully inflated."@en ;
+    vsso-core:belongsToVehicleComponent vsso:SeatLumbar ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Lumbar.Inflation"@en .
 
 vsso:LumbarUp a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "LumbarUp"@en ;
     skos:definition "Lumbar up switch engaged (SingleSeat.Lumbar.Height)"@en ;
+    vsso-core:belongsToVehicleComponent vsso:SwitchLumbar ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Lumbar.Up"@en .
 
 vsso:MassageDecrease a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "MassageDecrease"@en ;
     skos:definition "Decrease massage level switch engaged (SingleSeat.Massage)"@en ;
+    vsso-core:belongsToVehicleComponent vsso:SwitchMassage ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Massage.Decrease"@en .
 
 vsso:MassageIncrease a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "MassageIncrease"@en ;
     skos:definition "Increase massage level switch engaged (SingleSeat.Massage)"@en ;
+    vsso-core:belongsToVehicleComponent vsso:SwitchMassage ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Massage.Increase"@en .
 
 vsso:MaxTowBallWeight a owl:Class ;
     rdfs:label "MaxTowBallWeight"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Maximum vertical weight on the tow ball of a trailer."@en ;
     vsso-core:vssFacetedClassification "Vehicle.MaxTowBallWeight"@en .
 
 vsso:MaxTowWeight a owl:Class ;
     rdfs:label "MaxTowWeight"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Maximum weight of trailer."@en ;
     vsso-core:vssFacetedClassification "Vehicle.MaxTowWeight"@en .
 
@@ -1648,881 +1339,870 @@ vsso:MediaAction a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "MediaAction"@en ;
     skos:definition "Tells if the media was"@en ;
+    vsso-core:belongsToVehicleComponent vsso:InfotainmentMedia ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Media.Action"@en .
 
 vsso:MediaDeclinedURI a vsso-core:ObservableVehicleProperty ;
     rdfs:label "MediaDeclinedURI"@en ;
     skos:definition "URI of suggested media that was declined"@en ;
+    vsso-core:belongsToVehicleComponent vsso:InfotainmentMedia ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Media.DeclinedURI"@en .
-
-vsso:MediaPlayed a owl:Class ;
-    rdfs:label "MediaPlayed"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:InfotainmentMedia ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Collection of signals updated in concert when a new media is played"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Media.Played"@en .
 
 vsso:MediaSelectedURI a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "MediaSelectedURI"@en ;
     skos:definition "URI of suggested media that was selected"@en ;
+    vsso-core:belongsToVehicleComponent vsso:InfotainmentMedia ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Media.SelectedURI"@en .
 
 vsso:MediaVolume a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "MediaVolume"@en ;
     skos:definition "Current Media Volume"@en ;
+    vsso-core:belongsToVehicleComponent vsso:InfotainmentMedia ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Media.Volume"@en .
-
-vsso:MirrorsHeating a owl:Class ;
-    rdfs:label "MirrorsHeating"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BodyMirrors ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Mirror heater signals"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Body.Mirrors.Heating"@en .
 
 vsso:MirrorsHeatingStatus a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "MirrorsHeatingStatus"@en ;
     skos:definition "Mirror Heater on or off. True = Heater On. False = Heater Off."@en ;
+    vsso-core:belongsToVehicleComponent vsso:MirrorsHeating ;
     vsso-core:vssFacetedClassification "Vehicle.Body.Mirrors.Heating.Status"@en .
 
 vsso:MirrorsPan a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "MirrorsPan"@en ;
     skos:definition "Mirror pan as a percent. 0 = Center Position. 100 = Fully Left Position. -100 = Fully Right Position."@en ;
+    vsso-core:belongsToVehicleComponent vsso:BodyMirrors ;
     vsso-core:vssFacetedClassification "Vehicle.Body.Mirrors.Pan"@en .
 
 vsso:MirrorsTilt a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "MirrorsTilt"@en ;
     skos:definition "Mirror tilt as a percent. 0 = Center Position. 100 = Fully Upward Position. -100 = Fully Downward Position."@en ;
+    vsso-core:belongsToVehicleComponent vsso:BodyMirrors ;
     vsso-core:vssFacetedClassification "Vehicle.Body.Mirrors.Tilt"@en .
 
 vsso:MotorCoolantTemperature a vsso-core:ObservableVehicleProperty ;
     rdfs:label "MotorCoolantTemperature"@en ;
     skos:definition "Motor coolant temperature (if applicable)."@en ;
+    vsso-core:belongsToVehicleComponent vsso:ElectricMotorMotor ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.ElectricMotor.Motor.CoolantTemperature"@en .
 
 vsso:MotorPower a vsso-core:ObservableVehicleProperty ;
     rdfs:label "MotorPower"@en ;
     skos:definition "Current motor power output. Negative values indicate regen mode."@en ;
+    vsso-core:belongsToVehicleComponent vsso:ElectricMotorMotor ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.ElectricMotor.Motor.Power"@en .
 
 vsso:MotorRpm a vsso-core:ObservableVehicleProperty ;
     rdfs:label "MotorRpm"@en ;
     skos:definition "Motor rotational speed measured as rotations per minute. Negative values indicate reverse driving mode."@en ;
+    vsso-core:belongsToVehicleComponent vsso:ElectricMotorMotor ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.ElectricMotor.Motor.Rpm"@en .
 
 vsso:MotorTemperature a vsso-core:ObservableVehicleProperty ;
     rdfs:label "MotorTemperature"@en ;
     skos:definition "Motor temperature."@en ;
+    vsso-core:belongsToVehicleComponent vsso:ElectricMotorMotor ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.ElectricMotor.Motor.Temperature"@en .
 
 vsso:MotorTorque a vsso-core:ObservableVehicleProperty ;
     rdfs:label "MotorTorque"@en ;
     skos:definition "Current motor torque. Negative values indicate regen mode."@en ;
+    vsso-core:belongsToVehicleComponent vsso:ElectricMotorMotor ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.ElectricMotor.Motor.Torque"@en .
-
-vsso:NavigationCurrentLocation a owl:Class ;
-    rdfs:label "NavigationCurrentLocation"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:InfotainmentNavigation ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "The current latitude and longitude of the vehicle."@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Navigation.CurrentLocation"@en .
 
 vsso:NavigationCurrentLocationAccuracy a vsso-core:ObservableVehicleProperty ;
     rdfs:label "NavigationCurrentLocationAccuracy"@en ;
     skos:definition "Accuracy level of the latitude and longitude coordinates in meters."@en ;
+    vsso-core:belongsToVehicleComponent vsso:NavigationCurrentLocation ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Navigation.CurrentLocation.Accuracy"@en .
 
 vsso:NavigationCurrentLocationAltitude a vsso-core:ObservableVehicleProperty ;
     rdfs:label "NavigationCurrentLocationAltitude"@en ;
     skos:definition "Current elevation of the position in meters."@en ;
+    vsso-core:belongsToVehicleComponent vsso:NavigationCurrentLocation ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Navigation.CurrentLocation.Altitude"@en .
 
 vsso:NavigationCurrentLocationHeading a vsso-core:ObservableVehicleProperty ;
     rdfs:label "NavigationCurrentLocationHeading"@en ;
     skos:definition "Current magnetic compass heading, in degrees."@en ;
+    vsso-core:belongsToVehicleComponent vsso:NavigationCurrentLocation ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Navigation.CurrentLocation.Heading"@en .
 
 vsso:NavigationCurrentLocationLatitude a vsso-core:ObservableVehicleProperty ;
     rdfs:label "NavigationCurrentLocationLatitude"@en ;
     skos:definition "Current latitude of vehicle, as reported by GPS."@en ;
+    vsso-core:belongsToVehicleComponent vsso:NavigationCurrentLocation ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Navigation.CurrentLocation.Latitude"@en .
 
 vsso:NavigationCurrentLocationLongitude a vsso-core:ObservableVehicleProperty ;
     rdfs:label "NavigationCurrentLocationLongitude"@en ;
     skos:definition "Current longitude of vehicle, as reported by GPS."@en ;
+    vsso-core:belongsToVehicleComponent vsso:NavigationCurrentLocation ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Navigation.CurrentLocation.Longitude"@en .
-
-vsso:NavigationDestinationSet a owl:Class ;
-    rdfs:label "NavigationDestinationSet"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:InfotainmentNavigation ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "A navigation has been selected."@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Navigation.DestinationSet"@en .
 
 vsso:O2ShortTermFuelTrim a vsso-core:ObservableVehicleProperty ;
     rdfs:label "O2ShortTermFuelTrim"@en ;
     skos:definition "PID 1x (byte B) - Short term fuel trim"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBDO2 ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.O2.ShortTermFuelTrim"@en .
 
 vsso:O2Voltage a vsso-core:ObservableVehicleProperty ;
     rdfs:label "O2Voltage"@en ;
     skos:definition "PID 1x (byte A) - Sensor voltage"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBDO2 ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.O2.Voltage"@en .
 
 vsso:O2WRCurrent a vsso-core:ObservableVehicleProperty ;
     rdfs:label "O2WRCurrent"@en ;
     skos:definition "PID 3x (byte CD) - Current for wide range/band oxygen sensor"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBDO2WR ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.O2WR.Current"@en .
 
 vsso:O2WRLambda a vsso-core:ObservableVehicleProperty ;
     rdfs:label "O2WRLambda"@en ;
     skos:definition "PID 2x (byte AB) and PID 3x (byte AB) - Lambda for wide range/band oxygen sensor"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBDO2WR ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.O2WR.Lambda"@en .
 
 vsso:O2WRVoltage a vsso-core:ObservableVehicleProperty ;
     rdfs:label "O2WRVoltage"@en ;
     skos:definition "PID 2x (byte CD) - Voltage for wide range/band oxygen sensor"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBDO2WR ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.O2WR.Voltage"@en .
 
 vsso:OBDAbsoluteLoad a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDAbsoluteLoad"@en ;
     skos:definition "PID 43 - Absolute load value"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.AbsoluteLoad"@en .
 
 vsso:OBDAcceleratorPositionD a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDAcceleratorPositionD"@en ;
     skos:definition "PID 49 - Accelerator pedal position D"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.AcceleratorPositionD"@en .
 
 vsso:OBDAcceleratorPositionE a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDAcceleratorPositionE"@en ;
     skos:definition "PID 4A - Accelerator pedal position E"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.AcceleratorPositionE"@en .
 
 vsso:OBDAcceleratorPositionF a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDAcceleratorPositionF"@en ;
     skos:definition "PID 4B - Accelerator pedal position F"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.AcceleratorPositionF"@en .
 
 vsso:OBDAirStatus a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDAirStatus"@en ;
     skos:definition "PID 12 - Secondary air status"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.AirStatus"@en .
 
 vsso:OBDAmbientAirTemperature a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDAmbientAirTemperature"@en ;
     skos:definition "PID 46 - Ambient air temperature"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.AmbientAirTemperature"@en .
 
 vsso:OBDAuxInputStatus a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDAuxInputStatus"@en ;
     skos:definition "PID 1E - Auxiliary input status (power take off)"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.AuxInputStatus"@en .
 
 vsso:OBDBarometricPressure a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDBarometricPressure"@en ;
     skos:definition "PID 33 - Barometric pressure"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.BarometricPressure"@en .
 
 vsso:OBDCommandedEGR a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDCommandedEGR"@en ;
     skos:definition "PID 2C - Commanded exhaust gas recirculation (EGR)"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.CommandedEGR"@en .
 
 vsso:OBDCommandedEVAP a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDCommandedEVAP"@en ;
     skos:definition "PID 2E - Commanded evaporative purge (EVAP) valve"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.CommandedEVAP"@en .
 
 vsso:OBDCommandedEquivalenceRatio a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDCommandedEquivalenceRatio"@en ;
     skos:definition "PID 44 - Commanded equivalence ratio"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.CommandedEquivalenceRatio"@en .
 
 vsso:OBDControlModuleVoltage a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDControlModuleVoltage"@en ;
     skos:definition "PID 42 - Control module voltage"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.ControlModuleVoltage"@en .
 
 vsso:OBDCoolantTemperature a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDCoolantTemperature"@en ;
     skos:definition "PID 05 - Coolant temperature"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.CoolantTemperature"@en .
 
 vsso:OBDDTCList a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDDTCList"@en ;
     skos:definition "List of currently active DTCs formatted according OBD II (SAE-J2012DA_201812) standard ([P|C|B|U]XXXXX )"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.DTCList"@en .
 
 vsso:OBDDistanceSinceDTCClear a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDDistanceSinceDTCClear"@en ;
     skos:definition "PID 31 - Distance traveled since codes cleared"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.DistanceSinceDTCClear"@en .
 
 vsso:OBDDistanceWithMIL a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDDistanceWithMIL"@en ;
     skos:definition "PID 21 - Distance traveled with MIL on"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.DistanceWithMIL"@en .
-
-vsso:OBDDriveCycleStatus a owl:Class ;
-    rdfs:label "OBDDriveCycleStatus"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "PID 41 - OBD status for the current drive cycle"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.OBD.DriveCycleStatus"@en .
 
 vsso:OBDEGRError a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDEGRError"@en ;
     skos:definition "PID 2D - Exhaust gas recirculation (EGR) error"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.EGRError"@en .
 
 vsso:OBDEVAPVaporPressure a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDEVAPVaporPressure"@en ;
     skos:definition "PID 32 - Evaporative purge (EVAP) system pressure"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.EVAPVaporPressure"@en .
 
 vsso:OBDEVAPVaporPressureAbsolute a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDEVAPVaporPressureAbsolute"@en ;
     skos:definition "PID 53 - Absolute evaporative purge (EVAP) system pressure"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.EVAPVaporPressureAbsolute"@en .
 
 vsso:OBDEVAPVaporPressureAlternate a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDEVAPVaporPressureAlternate"@en ;
     skos:definition "PID 54 - Alternate evaporative purge (EVAP) system pressure"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.EVAPVaporPressureAlternate"@en .
 
 vsso:OBDEngineLoad a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDEngineLoad"@en ;
     skos:definition "PID 04 - Engine load in percent - 0 = no load, 100 = full load"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.EngineLoad"@en .
 
 vsso:OBDEngineSpeed a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDEngineSpeed"@en ;
     skos:definition "PID 0C - Engine speed measured as rotations per minute"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.EngineSpeed"@en .
 
 vsso:OBDEthanolPercent a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDEthanolPercent"@en ;
     skos:definition "PID 52 - Percentage of ethanol in the fuel"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.EthanolPercent"@en .
 
 vsso:OBDFreezeDTC a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDFreezeDTC"@en ;
     skos:definition "PID 02 - DTC that triggered the freeze frame"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.FreezeDTC"@en .
 
 vsso:OBDFuelInjectionTiming a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDFuelInjectionTiming"@en ;
     skos:definition "PID 5D - Fuel injection timing"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.FuelInjectionTiming"@en .
 
 vsso:OBDFuelLevel a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDFuelLevel"@en ;
     skos:definition "PID 2F - Fuel level in the fuel tank"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.FuelLevel"@en .
 
 vsso:OBDFuelPressure a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDFuelPressure"@en ;
     skos:definition "PID 0A - Fuel pressure"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.FuelPressure"@en .
 
 vsso:OBDFuelRailPressureAbsolute a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDFuelRailPressureAbsolute"@en ;
     skos:definition "PID 59 - Absolute fuel rail pressure"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.FuelRailPressureAbsolute"@en .
 
 vsso:OBDFuelRailPressureDirect a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDFuelRailPressureDirect"@en ;
     skos:definition "PID 23 - Fuel rail pressure direct inject"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.FuelRailPressureDirect"@en .
 
 vsso:OBDFuelRailPressureVac a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDFuelRailPressureVac"@en ;
     skos:definition "PID 22 - Fuel rail pressure relative to vacuum"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.FuelRailPressureVac"@en .
 
 vsso:OBDFuelRate a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDFuelRate"@en ;
     skos:definition "PID 5E - Engine fuel rate"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.FuelRate"@en .
 
 vsso:OBDFuelStatus a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDFuelStatus"@en ;
     skos:definition "PID 03 - Fuel status"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.FuelStatus"@en .
 
 vsso:OBDFuelType a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDFuelType"@en ;
     skos:definition "PID 51 - Fuel type"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.FuelType"@en .
 
 vsso:OBDHybridBatteryRemaining a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDHybridBatteryRemaining"@en ;
     skos:definition "PID 5B - Remaining life of hybrid battery"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.HybridBatteryRemaining"@en .
 
 vsso:OBDIntakeTemp a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDIntakeTemp"@en ;
     skos:definition "PID 0F - Intake temperature"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.IntakeTemp"@en .
 
 vsso:OBDLongTermFuelTrim1 a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDLongTermFuelTrim1"@en ;
     skos:definition "PID 07 - Long Term (learned) Fuel Trim - Bank 1 - negative percent leaner, positive percent richer"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.LongTermFuelTrim1"@en .
 
 vsso:OBDLongTermFuelTrim2 a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDLongTermFuelTrim2"@en ;
     skos:definition "PID 09 - Long Term (learned) Fuel Trim - Bank 2 - negative percent leaner, positive percent richer"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.LongTermFuelTrim2"@en .
 
 vsso:OBDLongTermO2Trim1 a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDLongTermO2Trim1"@en ;
     skos:definition "PID 56 (byte A) - Long term secondary O2 trim - Bank 1"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.LongTermO2Trim1"@en .
 
 vsso:OBDLongTermO2Trim2 a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDLongTermO2Trim2"@en ;
     skos:definition "PID 58 (byte A) - Long term secondary O2 trim - Bank 2"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.LongTermO2Trim2"@en .
 
 vsso:OBDLongTermO2Trim3 a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDLongTermO2Trim3"@en ;
     skos:definition "PID 56 (byte B) - Long term secondary O2 trim - Bank 3"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.LongTermO2Trim3"@en .
 
 vsso:OBDLongTermO2Trim4 a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDLongTermO2Trim4"@en ;
     skos:definition "PID 58 (byte B) - Long term secondary O2 trim - Bank 4"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.LongTermO2Trim4"@en .
 
 vsso:OBDMAF a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDMAF"@en ;
     skos:definition "PID 10 - Grams of air drawn into engine per second"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.MAF"@en .
 
 vsso:OBDMAP a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDMAP"@en ;
     skos:definition "PID 0B - Intake manifold pressure"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.MAP"@en .
 
 vsso:OBDMaxMAF a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDMaxMAF"@en ;
     skos:definition "PID 50 - Maximum flow for mass air flow sensor"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.MaxMAF"@en .
-
-vsso:OBDO2 a owl:Class ;
-    rdfs:label "OBDO2"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Oxygen sensors (PID 14 - PID 1B)"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.OBD.O2"@en .
-
-vsso:OBDO2WR a owl:Class ;
-    rdfs:label "OBDO2WR"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Wide range/band oxygen sensors (PID 24 - 2B and PID 34 - 3B)"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.OBD.O2WR"@en .
 
 vsso:OBDOBDStandards a owl:Class ;
     rdfs:label "OBDOBDStandards"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "PID 1C - OBD standards this vehicle conforms to"@en ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.OBDStandards"@en .
 
 vsso:OBDOilTemperature a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDOilTemperature"@en ;
     skos:definition "PID 5C - Engine oil temperature"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.OilTemperature"@en .
 
 vsso:OBDOxygenSensorsIn2Banks a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDOxygenSensorsIn2Banks"@en ;
     skos:definition "PID 13 - Presence of oxygen sensors in 2 banks. [A0..A3] == Bank 1, Sensors 1-4. [A4..A7] == Bank 2, Sensors 1-4"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.OxygenSensorsIn2Banks"@en .
 
 vsso:OBDOxygenSensorsIn4Banks a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDOxygenSensorsIn4Banks"@en ;
     skos:definition "PID 1D - Presence of oxygen sensors in 4 banks. Similar to PID 13, but [A0..A7] == [B1S1, B1S2, B2S1, B2S2, B3S1, B3S2, B4S1, B4S2]"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.OxygenSensorsIn4Banks"@en .
 
 vsso:OBDPidsA a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDPidsA"@en ;
     skos:definition "PID 00 - Bit array of the supported pids 01 to 20"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.PidsA"@en .
 
 vsso:OBDPidsB a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDPidsB"@en ;
     skos:definition "PID 20 - Bit array of the supported pids 21 to 40"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.PidsB"@en .
 
 vsso:OBDPidsC a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDPidsC"@en ;
     skos:definition "PID 40 - Bit array of the supported pids 41 to 60"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.PidsC"@en .
 
 vsso:OBDRelativeAcceleratorPosition a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDRelativeAcceleratorPosition"@en ;
     skos:definition "PID 5A - Relative accelerator pedal position"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.RelativeAcceleratorPosition"@en .
 
 vsso:OBDRelativeThrottlePosition a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDRelativeThrottlePosition"@en ;
     skos:definition "PID 45 - Relative throttle position"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.RelativeThrottlePosition"@en .
 
 vsso:OBDRunTime a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDRunTime"@en ;
     skos:definition "PID 1F - Engine run time"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.RunTime"@en .
 
 vsso:OBDRunTimeMIL a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDRunTimeMIL"@en ;
     skos:definition "PID 4D - Run time with MIL on"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.RunTimeMIL"@en .
 
 vsso:OBDShortTermFuelTrim1 a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDShortTermFuelTrim1"@en ;
     skos:definition "PID 06 - Short Term (immediate) Fuel Trim - Bank 1 - negative percent leaner, positive percent richer"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.ShortTermFuelTrim1"@en .
 
 vsso:OBDShortTermFuelTrim2 a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDShortTermFuelTrim2"@en ;
     skos:definition "PID 08 - Short Term (immediate) Fuel Trim - Bank 2 - negative percent leaner, positive percent richer"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.ShortTermFuelTrim2"@en .
 
 vsso:OBDShortTermO2Trim1 a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDShortTermO2Trim1"@en ;
     skos:definition "PID 55 (byte A) - Short term secondary O2 trim - Bank 1"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.ShortTermO2Trim1"@en .
 
 vsso:OBDShortTermO2Trim2 a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDShortTermO2Trim2"@en ;
     skos:definition "PID 57 (byte A) - Short term secondary O2 trim - Bank 2"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.ShortTermO2Trim2"@en .
 
 vsso:OBDShortTermO2Trim3 a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDShortTermO2Trim3"@en ;
     skos:definition "PID 55 (byte B) - Short term secondary O2 trim - Bank 3"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.ShortTermO2Trim3"@en .
 
 vsso:OBDShortTermO2Trim4 a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDShortTermO2Trim4"@en ;
     skos:definition "PID 57 (byte B) - Short term secondary O2 trim - Bank 4"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.ShortTermO2Trim4"@en .
 
 vsso:OBDSpeed a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDSpeed"@en ;
     skos:definition "PID 0D - Vehicle speed"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.Speed"@en .
-
-vsso:OBDStatus a owl:Class ;
-    rdfs:label "OBDStatus"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "PID 01 - OBD status"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.OBD.Status"@en .
 
 vsso:OBDThrottleActuator a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDThrottleActuator"@en ;
     skos:definition "PID 4C - Commanded throttle actuator"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.ThrottleActuator"@en .
 
 vsso:OBDThrottlePosition a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDThrottlePosition"@en ;
     skos:definition "PID 11 - Throttle position - 0 = closed throttle, 100 = open throttle"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.ThrottlePosition"@en .
 
 vsso:OBDThrottlePositionB a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDThrottlePositionB"@en ;
     skos:definition "PID 47 - Absolute throttle position B"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.ThrottlePositionB"@en .
 
 vsso:OBDThrottlePositionC a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDThrottlePositionC"@en ;
     skos:definition "PID 48 - Absolute throttle position C"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.ThrottlePositionC"@en .
 
 vsso:OBDTimeSinceDTCCleared a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDTimeSinceDTCCleared"@en ;
     skos:definition "PID 4E - Time since trouble codes cleared"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.TimeSinceDTCCleared"@en .
 
 vsso:OBDTimingAdvance a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDTimingAdvance"@en ;
     skos:definition "PID 0E - Time advance"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.TimingAdvance"@en .
 
 vsso:OBDWarmupsSinceDTCClear a vsso-core:ObservableVehicleProperty ;
     rdfs:label "OBDWarmupsSinceDTCClear"@en ;
     skos:definition "PID 30 - Number of warm-ups since codes cleared"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBD ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.WarmupsSinceDTCClear"@en .
 
 vsso:ObstacleDetectionError a vsso-core:ObservableVehicleProperty ;
     rdfs:label "ObstacleDetectionError"@en ;
     skos:definition "Indicates if obstacle sensor system incurred an error condition. True = Error. False = No Error."@en ;
+    vsso-core:belongsToVehicleComponent vsso:ADASObstacleDetection ;
     vsso-core:vssFacetedClassification "Vehicle.ADAS.ObstacleDetection.Error"@en .
 
 vsso:ObstacleDetectionIsActive a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "ObstacleDetectionIsActive"@en ;
     skos:definition "Indicates if obstacle sensor system is enabled. True = Enabled. False = Disabled."@en ;
+    vsso-core:belongsToVehicleComponent vsso:ADASObstacleDetection ;
     vsso-core:vssFacetedClassification "Vehicle.ADAS.ObstacleDetection.IsActive"@en .
-
-vsso:OccupantIdentifier a owl:Class ;
-    rdfs:label "OccupantIdentifier"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SeatOccupant ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Identifier attributes based on OAuth 2.0."@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Occupant.Identifier"@en .
 
 vsso:ParkingBrakeIsEngaged a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "ParkingBrakeIsEngaged"@en ;
     skos:definition "Parking brake status. True = Parking Brake is Engaged. False = Parking Brake is not Engaged."@en ;
+    vsso-core:belongsToVehicleComponent vsso:ChassisParkingBrake ;
     vsso-core:vssFacetedClassification "Vehicle.Chassis.ParkingBrake.IsEngaged"@en .
 
 vsso:PlayedAlbum a vsso-core:ObservableVehicleProperty ;
     rdfs:label "PlayedAlbum"@en ;
     skos:definition "Name of album being played"@en ;
+    vsso-core:belongsToVehicleComponent vsso:MediaPlayed ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Media.Played.Album"@en .
 
 vsso:PlayedArtist a vsso-core:ObservableVehicleProperty ;
     rdfs:label "PlayedArtist"@en ;
     skos:definition "Name of artist being played"@en ;
+    vsso-core:belongsToVehicleComponent vsso:MediaPlayed ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Media.Played.Artist"@en .
 
 vsso:PlayedSource a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "PlayedSource"@en ;
     skos:definition "Media selected for playback"@en ;
+    vsso-core:belongsToVehicleComponent vsso:MediaPlayed ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Media.Played.Source"@en .
 
 vsso:PlayedTrack a vsso-core:ObservableVehicleProperty ;
     rdfs:label "PlayedTrack"@en ;
     skos:definition "Name of track being played"@en ;
+    vsso-core:belongsToVehicleComponent vsso:MediaPlayed ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Media.Played.Track"@en .
 
 vsso:PlayedURI a vsso-core:ObservableVehicleProperty ;
     rdfs:label "PlayedURI"@en ;
     skos:definition "User Resource associated with the media"@en ;
+    vsso-core:belongsToVehicleComponent vsso:MediaPlayed ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Media.Played.URI"@en .
 
 vsso:PowertrainAccumulatedBrakingEnergy a vsso-core:ObservableVehicleProperty ;
     rdfs:label "PowertrainAccumulatedBrakingEnergy"@en ;
     skos:definition "The accumulated energy from regenerative braking over lifetime."@en ;
+    vsso-core:belongsToVehicleComponent vsso:Powertrain ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.AccumulatedBrakingEnergy"@en .
 
 vsso:PowertrainRange a vsso-core:ObservableVehicleProperty ;
     rdfs:label "PowertrainRange"@en ;
     skos:definition "Remaining range in meters using all energy sources available in the vehicle."@en ;
+    vsso-core:belongsToVehicleComponent vsso:Powertrain ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Range"@en .
 
-vsso:Private a owl:Class ;
+vsso:Private a vsso-core:VehicleComponent ;
     rdfs:label "Private"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
     skos:definition "Uncontrolled branch where non-public signals can be defined."@en ;
+    vsso-core:partOf vsso:Vehicle ;
     vsso-core:vssFacetedClassification "Vehicle.Private"@en .
 
 vsso:Raindetectionintensity a vsso-core:ObservableVehicleProperty ;
     rdfs:label "Raindetectionintensity"@en ;
     skos:definition "Rain intensity. 0 = Dry, No Rain. 100 = Covered."@en ;
+    vsso-core:belongsToVehicleComponent vsso:BodyRaindetection ;
     vsso-core:vssFacetedClassification "Vehicle.Body.Raindetection.intensity"@en .
 
 vsso:RearShadePosition a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "RearShadePosition"@en ;
     skos:definition "Position of window blind. 0 = Fully retracted. 100 = Fully deployed."@en ;
+    vsso-core:belongsToVehicleComponent vsso:CabinRearShade ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.RearShade.Position"@en .
 
 vsso:RearShadeSwitch a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "RearShadeSwitch"@en ;
     skos:definition "Switch controlling sliding action such as window, sunroof, or blind."@en ;
+    vsso-core:belongsToVehicleComponent vsso:CabinRearShade ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.RearShade.Switch"@en .
 
 vsso:RearviewMirrorDimmingLevel a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "RearviewMirrorDimmingLevel"@en ;
     skos:definition "Dimming level of rearview mirror. 0 = undimmed. 100 = fully dimmed"@en ;
+    vsso-core:belongsToVehicleComponent vsso:CabinRearviewMirror ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.RearviewMirror.DimmingLevel"@en .
 
 vsso:ReclineBackward a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "ReclineBackward"@en ;
     skos:definition "Seatback recline backward switch engaged (SingleSeat.Recline)"@en ;
+    vsso-core:belongsToVehicleComponent vsso:SwitchRecline ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Recline.Backward"@en .
 
 vsso:ReclineForward a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "ReclineForward"@en ;
     skos:definition "Seatback recline forward switch engaged (SingleSeat.Recline)"@en ;
+    vsso-core:belongsToVehicleComponent vsso:SwitchRecline ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Recline.Forward"@en .
 
 vsso:RoofLoad a owl:Class ;
     rdfs:label "RoofLoad"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "The permitted total weight of cargo and installations (e.g. a roof rack) on top of the vehicle."@en ;
     vsso-core:vssFacetedClassification "Vehicle.RoofLoad"@en .
-
-vsso:SeatAirbag a owl:Class ;
-    rdfs:label "SeatAirbag"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinSeat ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Airbag signals"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Airbag"@en .
-
-vsso:SeatCushion a owl:Class ;
-    rdfs:label "SeatCushion"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinSeat ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Cushion (leg support) signals."@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Cushion"@en .
 
 vsso:SeatHasPassenger a vsso-core:ObservableVehicleProperty ;
     rdfs:label "SeatHasPassenger"@en ;
     skos:definition "Does the seat have a passenger in it."@en ;
+    vsso-core:belongsToVehicleComponent vsso:CabinSeat ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.HasPassenger"@en .
-
-vsso:SeatHeadRestraint a owl:Class ;
-    rdfs:label "SeatHeadRestraint"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinSeat ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Head restraint settings"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.HeadRestraint"@en .
 
 vsso:SeatHeating a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "SeatHeating"@en ;
     skos:definition "Seat cooling / heating. 0 = off. -100 = max cold. +100 = max heat."@en ;
+    vsso-core:belongsToVehicleComponent vsso:CabinSeat ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Heating"@en .
 
 vsso:SeatHeight a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "SeatHeight"@en ;
     skos:definition "Seat vertical position. 0 = Lowermost. 1000 = Uppermost."@en ;
+    vsso-core:belongsToVehicleComponent vsso:CabinSeat ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Height"@en .
 
 vsso:SeatIsBelted a vsso-core:ObservableVehicleProperty ;
     rdfs:label "SeatIsBelted"@en ;
     skos:definition "Is the belt engaged."@en ;
+    vsso-core:belongsToVehicleComponent vsso:CabinSeat ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.IsBelted"@en .
-
-vsso:SeatLumbar a owl:Class ;
-    rdfs:label "SeatLumbar"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinSeat ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Lumbar signals"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Lumbar"@en .
 
 vsso:SeatMassage a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "SeatMassage"@en ;
     skos:definition "Seat massage level. 0 = off. 100 = max massage."@en ;
+    vsso-core:belongsToVehicleComponent vsso:CabinSeat ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Massage"@en .
 
 vsso:SeatPosition a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "SeatPosition"@en ;
     skos:definition "Seat horizontal position. 0 = Frontmost. 1000 = Rearmost."@en ;
+    vsso-core:belongsToVehicleComponent vsso:CabinSeat ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Position"@en .
 
 vsso:SeatRecline a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "SeatRecline"@en ;
     skos:definition "Recline level. -90 = Max forward recline. 90 max backward recline."@en ;
+    vsso-core:belongsToVehicleComponent vsso:CabinSeat ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Recline"@en .
-
-vsso:SeatSideBolster a owl:Class ;
-    rdfs:label "SeatSideBolster"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinSeat ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Side bolster settings"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.SideBolster"@en .
-
-vsso:Service a owl:Class ;
-    rdfs:label "Service"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Service data."@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Service"@en .
 
 vsso:ServiceDistanceToService a vsso-core:ObservableVehicleProperty ;
     rdfs:label "ServiceDistanceToService"@en ;
     skos:definition "Remaining distance to service (of any kind). Negative values indicate service overdue."@en ;
+    vsso-core:belongsToVehicleComponent vsso:Service ;
     vsso-core:vssFacetedClassification "Vehicle.Service.DistanceToService"@en .
 
 vsso:ServiceServiceDue a vsso-core:ObservableVehicleProperty ;
     rdfs:label "ServiceServiceDue"@en ;
     skos:definition "Indicates if vehicle needs service (of any kind). True = Service needed now or in the near future. False = No known need for service."@en ;
+    vsso-core:belongsToVehicleComponent vsso:Service ;
     vsso-core:vssFacetedClassification "Vehicle.Service.ServiceDue"@en .
 
 vsso:ServiceTimeToService a vsso-core:ObservableVehicleProperty ;
     rdfs:label "ServiceTimeToService"@en ;
     skos:definition "Remaining time to service (of any kind). Negative values indicate service overdue."@en ;
+    vsso-core:belongsToVehicleComponent vsso:Service ;
     vsso-core:vssFacetedClassification "Vehicle.Service.TimeToService"@en .
 
 vsso:ShadePosition a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "ShadePosition"@en ;
     skos:definition "Position of window blind. 0 = Fully retracted. 100 = Fully deployed."@en ;
+    vsso-core:belongsToVehicleComponent vsso:SunroofShade ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Sunroof.Shade.Position"@en .
 
 vsso:ShadeSwitch a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "ShadeSwitch"@en ;
     skos:definition "Switch controlling sliding action such as window, sunroof, or blind."@en ;
+    vsso-core:belongsToVehicleComponent vsso:SunroofShade ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Sunroof.Shade.Switch"@en .
 
 vsso:SideBolsterDeflate a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "SideBolsterDeflate"@en ;
     skos:definition "Side bolster deflation switch engaged (SingleSeat.SideBolster.Inflation)"@en ;
+    vsso-core:belongsToVehicleComponent vsso:SwitchSideBolster ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.SideBolster.Deflate"@en .
 
 vsso:SideBolsterInflate a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "SideBolsterInflate"@en ;
     skos:definition "Side bolster inflation switch engaged (SingleSeat.SideBolster.Inflation)"@en ;
+    vsso-core:belongsToVehicleComponent vsso:SwitchSideBolster ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.SideBolster.Inflate"@en .
 
 vsso:SideBolsterInflation a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "SideBolsterInflation"@en ;
     skos:definition "Side bolster support inflation. 0 = Fully deflated. 255 = Fully inflated."@en ;
+    vsso-core:belongsToVehicleComponent vsso:SeatSideBolster ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.SideBolster.Inflation"@en .
 
 vsso:Speed a vsso-core:ObservableVehicleProperty ;
     rdfs:label "Speed"@en ;
     skos:definition "Vehicle speed"@en ;
+    vsso-core:belongsToVehicleComponent vsso:Vehicle ;
     vsso-core:vssFacetedClassification "Vehicle.Speed"@en .
 
 vsso:SpotlightIsLeftOn a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "SpotlightIsLeftOn"@en ;
     skos:definition "Is light on the left side switched on"@en ;
+    vsso-core:belongsToVehicleComponent vsso:LightsSpotlight ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Lights.Spotlight.IsLeftOn"@en .
 
 vsso:SpotlightIsRightOn a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "SpotlightIsRightOn"@en ;
     skos:definition "Is light on the right side switched on"@en ;
+    vsso-core:belongsToVehicleComponent vsso:LightsSpotlight ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Lights.Spotlight.IsRightOn"@en .
 
 vsso:SpotlightIsSharedOn a vsso-core:ObservableVehicleProperty ;
     rdfs:label "SpotlightIsSharedOn"@en ;
     skos:definition "Is a shared light across a specific row on"@en ;
+    vsso-core:belongsToVehicleComponent vsso:LightsSpotlight ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Lights.Spotlight.IsSharedOn"@en .
 
 vsso:StateOfChargeCurrent a vsso-core:ObservableVehicleProperty ;
     rdfs:label "StateOfChargeCurrent"@en ;
     skos:definition "Physical state of charge of the high voltage battery. This is not necessarily the state of charge being displayed to the customer."@en ;
+    vsso-core:belongsToVehicleComponent vsso:BatteryStateOfCharge ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.StateOfCharge.Current"@en .
 
 vsso:StateOfChargeDisplayed a vsso-core:ObservableVehicleProperty ;
     rdfs:label "StateOfChargeDisplayed"@en ;
     skos:definition "State of charge displayed to the customer."@en ;
+    vsso-core:belongsToVehicleComponent vsso:BatteryStateOfCharge ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.StateOfCharge.Displayed"@en .
 
 vsso:StateOfChargeTarget a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "StateOfChargeTarget"@en ;
     skos:definition "Target state of charge set (eg. by customer)."@en ;
+    vsso-core:belongsToVehicleComponent vsso:BatteryStateOfCharge ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.StateOfCharge.Target"@en .
 
 vsso:StationAirDistribution a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "StationAirDistribution"@en ;
     skos:definition "Direction of airstream"@en ;
+    vsso-core:belongsToVehicleComponent vsso:HVACStation ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.HVAC.Station.AirDistribution"@en .
 
 vsso:StationFanSpeed a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "StationFanSpeed"@en ;
     skos:definition "Fan Speed, 0 = off. 100 = max"@en ;
+    vsso-core:belongsToVehicleComponent vsso:HVACStation ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.HVAC.Station.FanSpeed"@en .
 
 vsso:StationTemperature a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "StationTemperature"@en ;
     skos:definition "Temperature"@en ;
+    vsso-core:belongsToVehicleComponent vsso:HVACStation ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.HVAC.Station.Temperature"@en .
 
 vsso:StatusDTCCount a vsso-core:ObservableVehicleProperty ;
     rdfs:label "StatusDTCCount"@en ;
     skos:definition "Number of sensor Trouble Codes (DTC)"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBDStatus ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.Status.DTCCount"@en .
 
 vsso:StatusIgnitionType a vsso-core:ObservableVehicleProperty ;
     rdfs:label "StatusIgnitionType"@en ;
     skos:definition "Type of the ignition for ICE - spark = spark plug ignition, compression = self-igniting (Diesel engines)"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBDStatus ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.Status.IgnitionType"@en .
 
 vsso:StatusMIL a vsso-core:ObservableVehicleProperty ;
     rdfs:label "StatusMIL"@en ;
     skos:definition "Malfunction Indicator Light (MIL) False = Off, True = On"@en ;
+    vsso-core:belongsToVehicleComponent vsso:OBDStatus ;
     vsso-core:vssFacetedClassification "Vehicle.OBD.Status.MIL"@en .
 
 vsso:SteeringWheelAngle a vsso-core:ObservableVehicleProperty ;
     rdfs:label "SteeringWheelAngle"@en ;
     skos:definition "Steering wheel angle. Positive = degrees to the left. Negative = degrees to the right."@en ;
+    vsso-core:belongsToVehicleComponent vsso:ChassisSteeringWheel ;
     vsso-core:vssFacetedClassification "Vehicle.Chassis.SteeringWheel.Angle"@en .
 
 vsso:SteeringWheelExtension a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "SteeringWheelExtension"@en ;
     skos:definition "Steering wheel column extension from dashboard. 0 = Closest to dashboard. 100 = Furthest from dashboard."@en ;
+    vsso-core:belongsToVehicleComponent vsso:ChassisSteeringWheel ;
     vsso-core:vssFacetedClassification "Vehicle.Chassis.SteeringWheel.Extension"@en .
 
 vsso:SteeringWheelPosition a owl:Class ;
     rdfs:label "SteeringWheelPosition"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ChassisSteeringWheel ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Position of the steering wheel on the left or right side of the vehicle."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Chassis.SteeringWheel.Position"@en .
 
@@ -2530,191 +2210,136 @@ vsso:SteeringWheelTilt a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "SteeringWheelTilt"@en ;
     skos:definition "Steering wheel column tilt. 0 = Lowest position. 100 = Highest position."@en ;
+    vsso-core:belongsToVehicleComponent vsso:ChassisSteeringWheel ;
     vsso-core:vssFacetedClassification "Vehicle.Chassis.SteeringWheel.Tilt"@en .
 
 vsso:SunroofPosition a vsso-core:ObservableVehicleProperty ;
     rdfs:label "SunroofPosition"@en ;
     skos:definition "Sunroof position. 0 = Fully closed 100 = Fully opened. -100 = Fully tilted"@en ;
+    vsso-core:belongsToVehicleComponent vsso:CabinSunroof ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Sunroof.Position"@en .
-
-vsso:SunroofShade a owl:Class ;
-    rdfs:label "SunroofShade"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinSunroof ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Sun roof shade status"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Cabin.Sunroof.Shade"@en .
 
 vsso:SunroofSwitch a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "SunroofSwitch"@en ;
     skos:definition "Switch controlling sliding action such as window, sunroof, or shade."@en ;
+    vsso-core:belongsToVehicleComponent vsso:CabinSunroof ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Sunroof.Switch"@en .
 
 vsso:SwitchBackward a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "SwitchBackward"@en ;
     skos:definition "Seat backward switch engaged (SingleSeat.Position)"@en ;
+    vsso-core:belongsToVehicleComponent vsso:SeatSwitch ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Backward"@en .
 
 vsso:SwitchCooler a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "SwitchCooler"@en ;
     skos:definition "Cooler switch for Seat heater (SingleSeat.Heating)"@en ;
+    vsso-core:belongsToVehicleComponent vsso:SeatSwitch ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Cooler"@en .
-
-vsso:SwitchCushion a owl:Class ;
-    rdfs:label "SwitchCushion"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SeatSwitch ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Switches for SingleSeat.Cushion"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Cushion"@en .
 
 vsso:SwitchDown a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "SwitchDown"@en ;
     skos:definition "Seat down switch engaged (SingleSeat.Height)"@en ;
+    vsso-core:belongsToVehicleComponent vsso:SeatSwitch ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Down"@en .
 
 vsso:SwitchForward a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "SwitchForward"@en ;
     skos:definition "Seat forward switch engaged (SingleSeat.Position)"@en ;
+    vsso-core:belongsToVehicleComponent vsso:SeatSwitch ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Forward"@en .
-
-vsso:SwitchHeadRestraint a owl:Class ;
-    rdfs:label "SwitchHeadRestraint"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SeatSwitch ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Switches for SingleSeat.HeadRestraint.Height"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.HeadRestraint"@en .
-
-vsso:SwitchLumbar a owl:Class ;
-    rdfs:label "SwitchLumbar"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SeatSwitch ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Switches for SingleSeat.Lumbar"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Lumbar"@en .
-
-vsso:SwitchMassage a owl:Class ;
-    rdfs:label "SwitchMassage"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SeatSwitch ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Switches for SingleSeat.Massage"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Massage"@en .
-
-vsso:SwitchRecline a owl:Class ;
-    rdfs:label "SwitchRecline"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SeatSwitch ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Switches for SingleSeat.Recline"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Recline"@en .
-
-vsso:SwitchSideBolster a owl:Class ;
-    rdfs:label "SwitchSideBolster"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:SeatSwitch ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Switches for SingleSeat.SideBolster"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.SideBolster"@en .
 
 vsso:SwitchUp a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "SwitchUp"@en ;
     skos:definition "Seat up switch engaged (SingleSeat.Height)"@en ;
+    vsso-core:belongsToVehicleComponent vsso:SeatSwitch ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Up"@en .
 
 vsso:SwitchWarmer a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "SwitchWarmer"@en ;
     skos:definition "Warmer switch for Seat heater (SingleSeat.Heating)"@en ;
+    vsso-core:belongsToVehicleComponent vsso:SeatSwitch ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Warmer"@en .
 
 vsso:TCSError a vsso-core:ObservableVehicleProperty ;
     rdfs:label "TCSError"@en ;
     skos:definition "Indicates if TCS incurred an error condition. True = Error. False = No Error."@en ;
+    vsso-core:belongsToVehicleComponent vsso:ADASTCS ;
     vsso-core:vssFacetedClassification "Vehicle.ADAS.TCS.Error"@en .
 
 vsso:TCSIsActive a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "TCSIsActive"@en ;
     skos:definition "Indicates if TCS is enabled. True = Enabled. False = Disabled."@en ;
+    vsso-core:belongsToVehicleComponent vsso:ADASTCS ;
     vsso-core:vssFacetedClassification "Vehicle.ADAS.TCS.IsActive"@en .
 
 vsso:TCSIsEngaged a vsso-core:ObservableVehicleProperty ;
     rdfs:label "TCSIsEngaged"@en ;
     skos:definition "Indicates if TCS is currently regulating traction. True = Engaged. False = Not Engaged."@en ;
+    vsso-core:belongsToVehicleComponent vsso:ADASTCS ;
     vsso-core:vssFacetedClassification "Vehicle.ADAS.TCS.IsEngaged"@en .
 
 vsso:TimerMode a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "TimerMode"@en ;
     skos:definition "Defines whether Timer.Time is defining start- or endtime of a charging action; departuretime denotes that target time should be taken from vehicle-level desired departure-time setting."@en ;
+    vsso-core:belongsToVehicleComponent vsso:ChargingTimer ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Charging.Timer.Mode"@en .
 
 vsso:TimerTime a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "TimerTime"@en ;
     skos:definition "Time value for next charging-related action (Unix timestamp, seconds)."@en ;
+    vsso-core:belongsToVehicleComponent vsso:ChargingTimer ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Charging.Timer.Time"@en .
 
 vsso:TirePressure a vsso-core:ObservableVehicleProperty ;
     rdfs:label "TirePressure"@en ;
     skos:definition "Tire pressure in kilo-Pascal"@en ;
+    vsso-core:belongsToVehicleComponent vsso:WheelTire ;
     vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle.Wheel.Tire.Pressure"@en .
 
 vsso:TirePressureLow a vsso-core:ObservableVehicleProperty ;
     rdfs:label "TirePressureLow"@en ;
     skos:definition "Tire Pressure Status. True = Low tire pressure. False = Good tire pressure."@en ;
+    vsso-core:belongsToVehicleComponent vsso:WheelTire ;
     vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle.Wheel.Tire.PressureLow"@en .
 
 vsso:TireTemperature a vsso-core:ObservableVehicleProperty ;
     rdfs:label "TireTemperature"@en ;
     skos:definition "Tire temperature in Celsius."@en ;
+    vsso-core:belongsToVehicleComponent vsso:WheelTire ;
     vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle.Wheel.Tire.Temperature"@en .
-
-vsso:Trailer a owl:Class ;
-    rdfs:label "Trailer"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Trailer signals"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Trailer"@en .
 
 vsso:TrailerConnected a vsso-core:ObservableVehicleProperty ;
     rdfs:label "TrailerConnected"@en ;
     skos:definition "Signal indicating if trailer is connected or not."@en ;
+    vsso-core:belongsToVehicleComponent vsso:Trailer ;
     vsso-core:vssFacetedClassification "Vehicle.Trailer.Connected"@en .
 
 vsso:TransmissionClutchWear a vsso-core:ObservableVehicleProperty ;
     rdfs:label "TransmissionClutchWear"@en ;
     skos:definition "Clutch wear as a percent. 0 = no wear. 100 = worn."@en ;
+    vsso-core:belongsToVehicleComponent vsso:PowertrainTransmission ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Transmission.ClutchWear"@en .
 
 vsso:TransmissionCurrentGear a vsso-core:ObservableVehicleProperty ;
     rdfs:label "TransmissionCurrentGear"@en ;
     skos:definition "The current gear. 0=Neutral, 1/2/..=Forward, -1/..=Reverse"@en ;
+    vsso-core:belongsToVehicleComponent vsso:PowertrainTransmission ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Transmission.CurrentGear"@en .
 
 vsso:TransmissionDriveType a owl:Class ;
     rdfs:label "TransmissionDriveType"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainTransmission ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Drive type."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Transmission.DriveType"@en .
 
@@ -2722,20 +2347,19 @@ vsso:TransmissionGear a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "TransmissionGear"@en ;
     skos:definition "Current gear. 0=Neutral. -1=Reverse"@en ;
+    vsso-core:belongsToVehicleComponent vsso:PowertrainTransmission ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Transmission.Gear"@en .
 
 vsso:TransmissionGearChangeMode a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "TransmissionGearChangeMode"@en ;
     skos:definition "Is the gearbox in automatic or manual (paddle) mode."@en ;
+    vsso-core:belongsToVehicleComponent vsso:PowertrainTransmission ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Transmission.GearChangeMode"@en .
 
 vsso:TransmissionGearCount a owl:Class ;
     rdfs:label "TransmissionGearCount"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainTransmission ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Number of forward gears in the transmission. -1 = CVT."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Transmission.GearCount"@en .
 
@@ -2743,666 +2367,826 @@ vsso:TransmissionPerformanceMode a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "TransmissionPerformanceMode"@en ;
     skos:definition "Current gearbox performance mode."@en ;
+    vsso-core:belongsToVehicleComponent vsso:PowertrainTransmission ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Transmission.PerformanceMode"@en .
 
 vsso:TransmissionSelectedGear a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "TransmissionSelectedGear"@en ;
     skos:definition "The selected gear. 0=Neutral, 1/2/..=Forward, -1/..=Reverse, 126=Park, 127=Drive"@en ;
+    vsso-core:belongsToVehicleComponent vsso:PowertrainTransmission ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Transmission.SelectedGear"@en .
 
 vsso:TransmissionSpeed a vsso-core:ObservableVehicleProperty ;
     rdfs:label "TransmissionSpeed"@en ;
     skos:definition "Vehicle speed, as sensed by the gearbox."@en ;
+    vsso-core:belongsToVehicleComponent vsso:PowertrainTransmission ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Transmission.Speed"@en .
 
 vsso:TransmissionTemperature a vsso-core:ObservableVehicleProperty ;
     rdfs:label "TransmissionTemperature"@en ;
     skos:definition "The current gearbox temperature"@en ;
+    vsso-core:belongsToVehicleComponent vsso:PowertrainTransmission ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Transmission.Temperature"@en .
 
 vsso:TransmissionTravelledDistance a vsso-core:ObservableVehicleProperty ;
     rdfs:label "TransmissionTravelledDistance"@en ;
     skos:definition "Odometer reading, total distance travelled during the lifetime of the transmission."@en ;
+    vsso-core:belongsToVehicleComponent vsso:PowertrainTransmission ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Transmission.TravelledDistance"@en .
 
 vsso:TransmissionType a owl:Class ;
     rdfs:label "TransmissionType"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainTransmission ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Transmission type."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.Transmission.Type"@en .
 
 vsso:TravelledDistance a vsso-core:ObservableVehicleProperty ;
     rdfs:label "TravelledDistance"@en ;
     skos:definition "Odometer reading, total distance travelled during the lifetime of the vehicle."@en ;
+    vsso-core:belongsToVehicleComponent vsso:Vehicle ;
     vsso-core:vssFacetedClassification "Vehicle.TravelledDistance"@en .
 
 vsso:TripMeterReading a vsso-core:ObservableVehicleProperty ;
     rdfs:label "TripMeterReading"@en ;
     skos:definition "Current trip meter reading"@en ;
+    vsso-core:belongsToVehicleComponent vsso:Vehicle ;
     vsso-core:vssFacetedClassification "Vehicle.TripMeterReading"@en .
 
 vsso:TrunkIsLocked a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "TrunkIsLocked"@en ;
     skos:definition "Is trunk locked or unlocked. True = Locked. False = Unlocked."@en ;
+    vsso-core:belongsToVehicleComponent vsso:BodyTrunk ;
     vsso-core:vssFacetedClassification "Vehicle.Body.Trunk.IsLocked"@en .
 
 vsso:TrunkIsOpen a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "TrunkIsOpen"@en ;
     skos:definition "Trunk open or closed. True = Open. False = Closed"@en ;
+    vsso-core:belongsToVehicleComponent vsso:BodyTrunk ;
     vsso-core:vssFacetedClassification "Vehicle.Body.Trunk.IsOpen"@en .
 
-vsso:Vehicle rdfs:label "Vehicle"@en ;
-    skos:definition "High-level vehicle data."@en ;
-    vsso-core:vssFacetedClassification "Vehicle"@en .
+vsso:VehicleIdentification a vsso-core:VehicleComponent ;
+    rdfs:label "VehicleIdentification"@en ;
+    skos:definition "Attributes that identify a vehicle"@en ;
+    vsso-core:partOf vsso:Vehicle ;
+    vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification"@en .
 
 vsso:VehicleIdentificationACRISSCode a owl:Class ;
     rdfs:label "VehicleIdentificationACRISSCode"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VehicleIdentification ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "The ACRISS Car Classification Code is a code used by many car rental companies."@en ;
     vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification.ACRISSCode"@en .
 
 vsso:VehicleIdentificationBrand a owl:Class ;
     rdfs:label "VehicleIdentificationBrand"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VehicleIdentification ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Vehicle brand or manufacturer"@en ;
     vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification.Brand"@en .
 
 vsso:VehicleIdentificationModel a owl:Class ;
     rdfs:label "VehicleIdentificationModel"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VehicleIdentification ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Vehicle model"@en ;
     vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification.Model"@en .
 
 vsso:VehicleIdentificationVIN a owl:Class ;
     rdfs:label "VehicleIdentificationVIN"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VehicleIdentification ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "17-character Vehicle Identification Number (VIN) as defined by ISO 3779"@en ;
     vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification.VIN"@en .
 
 vsso:VehicleIdentificationWMI a owl:Class ;
     rdfs:label "VehicleIdentificationWMI"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VehicleIdentification ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "3-character World Manufacturer Identification (WMI) as defined by ISO 3780"@en ;
     vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification.WMI"@en .
 
 vsso:VehicleIdentificationYear a owl:Class ;
     rdfs:label "VehicleIdentificationYear"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VehicleIdentification ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Model year of the vehicle"@en ;
     vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification.Year"@en .
 
 vsso:VehicleIdentificationbodyType a owl:Class ;
     rdfs:label "VehicleIdentificationbodyType"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VehicleIdentification ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Indicates the design and body style of the vehicle (e.g. station wagon, hatchback, etc.)."@en ;
     vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification.bodyType"@en .
 
 vsso:VehicleIdentificationdateVehicleFirstRegistered a owl:Class ;
     rdfs:label "VehicleIdentificationdateVehicleFirstRegistered"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VehicleIdentification ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "The date of the first registration of the vehicle with the respective public authorities."@en ;
     vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification.dateVehicleFirstRegistered"@en .
 
 vsso:VehicleIdentificationknownVehicleDamages a owl:Class ;
     rdfs:label "VehicleIdentificationknownVehicleDamages"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VehicleIdentification ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "A textual description of known damages, both repaired and unrepaired."@en ;
     vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification.knownVehicleDamages"@en .
 
 vsso:VehicleIdentificationmeetsEmissionStandard a owl:Class ;
     rdfs:label "VehicleIdentificationmeetsEmissionStandard"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VehicleIdentification ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Indicates that the vehicle meets the respective emission standard."@en ;
     vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification.meetsEmissionStandard"@en .
 
 vsso:VehicleIdentificationproductionDate a owl:Class ;
     rdfs:label "VehicleIdentificationproductionDate"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VehicleIdentification ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "The date of production of the item, e.g. vehicle."@en ;
     vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification.productionDate"@en .
 
 vsso:VehicleIdentificationpurchaseDate a owl:Class ;
     rdfs:label "VehicleIdentificationpurchaseDate"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VehicleIdentification ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "The date the item e.g. vehicle was purchased by the current owner."@en ;
     vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification.purchaseDate"@en .
 
 vsso:VehicleIdentificationvehicleConfiguration a owl:Class ;
     rdfs:label "VehicleIdentificationvehicleConfiguration"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VehicleIdentification ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "A short text indicating the configuration of the vehicle, e.g. '5dr hatchback ST 2.5 MT 225 hp' or 'limited edition'."@en ;
     vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification.vehicleConfiguration"@en .
 
 vsso:VehicleIdentificationvehicleModelDate a owl:Class ;
     rdfs:label "VehicleIdentificationvehicleModelDate"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VehicleIdentification ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "The release date of a vehicle model (often used to differentiate versions of the same make and model)."@en ;
     vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification.vehicleModelDate"@en .
 
 vsso:VehicleIdentificationvehicleSeatingCapacity a owl:Class ;
     rdfs:label "VehicleIdentificationvehicleSeatingCapacity"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VehicleIdentification ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "The number of passengers that can be seated in the vehicle, both in terms of the physical space available, and in terms of limitations set by law."@en ;
     vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification.vehicleSeatingCapacity"@en .
 
 vsso:VehicleIdentificationvehicleSpecialUsage a owl:Class ;
     rdfs:label "VehicleIdentificationvehicleSpecialUsage"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VehicleIdentification ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Indicates whether the vehicle has been used for special purposes, like commercial rental, driving school."@en ;
     vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification.vehicleSpecialUsage"@en .
 
 vsso:VehicleIdentificationvehicleinteriorColor a owl:Class ;
     rdfs:label "VehicleIdentificationvehicleinteriorColor"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VehicleIdentification ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "The color or color combination of the interior of the vehicle."@en ;
     vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification.vehicleinteriorColor"@en .
 
 vsso:VehicleIdentificationvehicleinteriorType a owl:Class ;
     rdfs:label "VehicleIdentificationvehicleinteriorType"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VehicleIdentification ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "The type or material of the interior of the vehicle (e.g. synthetic fabric, leather, wood, etc.)."@en ;
     vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification.vehicleinteriorType"@en .
 
+vsso:VersionVSS a vsso-core:VehicleComponent ;
+    rdfs:label "VersionVSS"@en ;
+    skos:definition "Supported Version of VSS"@en ;
+    vsso-core:partOf vsso:Vehicle ;
+    vsso-core:vssFacetedClassification "Vehicle.VersionVSS"@en .
+
 vsso:VersionVSSLabel a owl:Class ;
     rdfs:label "VersionVSSLabel"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VersionVSS ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Label to further describe the version"@en ;
     vsso-core:vssFacetedClassification "Vehicle.VersionVSS.Label"@en .
 
 vsso:VersionVSSMajor a owl:Class ;
     rdfs:label "VersionVSSMajor"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VersionVSS ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Supported Version of VSS - Major version"@en ;
     vsso-core:vssFacetedClassification "Vehicle.VersionVSS.Major"@en .
 
 vsso:VersionVSSMinor a owl:Class ;
     rdfs:label "VersionVSSMinor"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VersionVSS ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Supported Version of VSS - Minor version"@en ;
     vsso-core:vssFacetedClassification "Vehicle.VersionVSS.Minor"@en .
 
 vsso:VersionVSSPatch a owl:Class ;
     rdfs:label "VersionVSSPatch"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:VersionVSS ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Supported Version of VSS - Patch version"@en ;
     vsso-core:vssFacetedClassification "Vehicle.VersionVSS.Patch"@en .
 
 vsso:WasherFluidLevel a vsso-core:ObservableVehicleProperty ;
     rdfs:label "WasherFluidLevel"@en ;
     skos:definition "Washer fluid level as a percent. 0 = Empty. 100 = Full."@en ;
+    vsso-core:belongsToVehicleComponent vsso:WindshieldWasherFluid ;
     vsso-core:vssFacetedClassification "Vehicle.Body.Windshield.WasherFluid.Level"@en .
 
 vsso:WasherFluidLevelLow a vsso-core:ObservableVehicleProperty ;
     rdfs:label "WasherFluidLevelLow"@en ;
     skos:definition "Low level indication for washer fluid. True = Level Low. False = Level OK."@en ;
+    vsso-core:belongsToVehicleComponent vsso:WindshieldWasherFluid ;
     vsso-core:vssFacetedClassification "Vehicle.Body.Windshield.WasherFluid.LevelLow"@en .
-
-vsso:WheelBrake a owl:Class ;
-    rdfs:label "WheelBrake"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:AxleWheel ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Brake signals for wheel"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle.Wheel.Brake"@en .
-
-vsso:WheelTire a owl:Class ;
-    rdfs:label "WheelTire"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:AxleWheel ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Tire signals for wheel"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle.Wheel.Tire"@en .
 
 vsso:Width a owl:Class ;
     rdfs:label "Width"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "Overall vehicle width."@en ;
     vsso-core:vssFacetedClassification "Vehicle.Width"@en .
 
 vsso:WindowChildLock a vsso-core:ObservableVehicleProperty ;
     rdfs:label "WindowChildLock"@en ;
     skos:definition "Is window child lock engaged. True = Engaged. False = Disengaged."@en ;
+    vsso-core:belongsToVehicleComponent vsso:DoorWindow ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Door.Window.ChildLock"@en .
 
 vsso:WindowPosition a vsso-core:ObservableVehicleProperty ;
     rdfs:label "WindowPosition"@en ;
     skos:definition "Window position. 0 = Fully closed 100 = Fully opened."@en ;
+    vsso-core:belongsToVehicleComponent vsso:DoorWindow ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Door.Window.Position"@en .
 
 vsso:WindowSwitch a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "WindowSwitch"@en ;
     skos:definition "Switch controlling sliding action such as window, sunroof, or blind."@en ;
+    vsso-core:belongsToVehicleComponent vsso:DoorWindow ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Door.Window.Switch"@en .
 
 vsso:WindowisOpen a vsso-core:ObservableVehicleProperty ;
     rdfs:label "WindowisOpen"@en ;
     skos:definition "Is window open or closed"@en ;
+    vsso-core:belongsToVehicleComponent vsso:DoorWindow ;
     vsso-core:vssFacetedClassification "Vehicle.Cabin.Door.Window.isOpen"@en .
-
-vsso:WindshieldHeating a owl:Class ;
-    rdfs:label "WindshieldHeating"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BodyWindshield ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Windshield heater signals"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Body.Windshield.Heating"@en .
-
-vsso:WindshieldWasherFluid a owl:Class ;
-    rdfs:label "WindshieldWasherFluid"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BodyWindshield ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Windshield washer fluid signals"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Body.Windshield.WasherFluid"@en .
-
-vsso:WindshieldWiping a owl:Class ;
-    rdfs:label "WindshieldWiping"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:BodyWindshield ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Windshield wiper signals"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Body.Windshield.Wiping"@en .
 
 vsso:WipingStatus a vsso-core:ActuatableVehicleProperty,
         vsso-core:ObservableVehicleProperty ;
     rdfs:label "WipingStatus"@en ;
     skos:definition "Wiper status"@en ;
+    vsso-core:belongsToVehicleComponent vsso:WindshieldWiping ;
     vsso-core:vssFacetedClassification "Vehicle.Body.Windshield.Wiping.Status"@en .
 
 vsso:accelerationTime a owl:Class ;
     rdfs:label "accelerationTime"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "The time needed to accelerate the vehicle from a given start velocity to a given target velocity."@en ;
     vsso-core:vssFacetedClassification "Vehicle.accelerationTime"@en .
 
 vsso:cargoVolume a owl:Class ;
     rdfs:label "cargoVolume"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "The available volume for cargo or luggage. For automobiles, this is usually the trunk volume."@en ;
     vsso-core:vssFacetedClassification "Vehicle.cargoVolume"@en .
 
 vsso:emissionsCO2 a owl:Class ;
     rdfs:label "emissionsCO2"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:belongsToVehicleComponent ],
-        vsso-core:StaticVehicleProperty ;
+    rdfs:subClassOf vsso-core:StaticVehicleProperty ;
     skos:definition "The CO2 emissions."@en ;
     vsso-core:vssFacetedClassification "Vehicle.emissionsCO2"@en .
 
-vsso:BodyChargingPort a owl:Class ;
-    rdfs:label "BodyChargingPort"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Body ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Collects Information about the charging port"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Body.ChargingPort"@en .
+vsso:BodyHood a vsso-core:VehicleComponent ;
+    rdfs:label "BodyHood"@en ;
+    skos:definition "Hood status"@en ;
+    vsso-core:partOf vsso:Body ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Hood"@en .
 
-vsso:BodyMirrors a owl:Class ;
-    rdfs:label "BodyMirrors"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Body ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "All mirrors"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Body.Mirrors"@en .
+vsso:BodyHorn a vsso-core:VehicleComponent ;
+    rdfs:label "BodyHorn"@en ;
+    skos:definition "Horn signals"@en ;
+    vsso-core:partOf vsso:Body ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Horn"@en .
 
-vsso:CabinHVAC a owl:Class ;
-    rdfs:label "CabinHVAC"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Cabin ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Climate control"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Cabin.HVAC"@en .
+vsso:BodyRaindetection a vsso-core:VehicleComponent ;
+    rdfs:label "BodyRaindetection"@en ;
+    skos:definition "Rainsensor signals"@en ;
+    vsso-core:partOf vsso:Body ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Raindetection"@en .
 
-vsso:CabinLights a owl:Class ;
-    rdfs:label "CabinLights"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Cabin ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Interior lights signals and sensors"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Cabin.Lights"@en .
+vsso:CabinConvertible a vsso-core:VehicleComponent ;
+    rdfs:label "CabinConvertible"@en ;
+    skos:definition "Convertible roof"@en ;
+    vsso-core:partOf vsso:Cabin ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Convertible"@en .
 
-vsso:CabinSunroof a owl:Class ;
-    rdfs:label "CabinSunroof"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Cabin ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Sun roof status."@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Cabin.Sunroof"@en .
+vsso:CabinRearviewMirror a vsso-core:VehicleComponent ;
+    rdfs:label "CabinRearviewMirror"@en ;
+    skos:definition "Rearview mirror"@en ;
+    vsso-core:partOf vsso:Cabin ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.RearviewMirror"@en .
 
-vsso:ChassisSteeringWheel a owl:Class ;
-    rdfs:label "ChassisSteeringWheel"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Chassis ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Steering wheel signals"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Chassis.SteeringWheel"@en .
+vsso:ChassisAccelerator a vsso-core:VehicleComponent ;
+    rdfs:label "ChassisAccelerator"@en ;
+    skos:definition "Accelerator signals"@en ;
+    vsso-core:partOf vsso:Chassis ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.Accelerator"@en .
 
-vsso:Driver a owl:Class ;
-    rdfs:label "Driver"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Driver data."@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Driver"@en .
-
-vsso:InfotainmentMedia a owl:Class ;
-    rdfs:label "InfotainmentMedia"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinInfotainment ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "All Media actions"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Media"@en .
-
-vsso:SeatOccupant a owl:Class ;
-    rdfs:label "SeatOccupant"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinSeat ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Occupant data."@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Occupant"@en .
-
-vsso:AxleWheel a owl:Class ;
-    rdfs:label "AxleWheel"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:ChassisAxle ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Wheel signals for axle"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle.Wheel"@en .
-
-vsso:BatteryCharging a owl:Class ;
-    rdfs:label "BatteryCharging"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:PowertrainBattery ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Properties related to battery charging"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Charging"@en .
-
-vsso:CabinDoor a owl:Class ;
-    rdfs:label "CabinDoor"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Cabin ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "All doors, including windows and switches"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Cabin.Door"@en .
-
-vsso:InfotainmentNavigation a owl:Class ;
-    rdfs:label "InfotainmentNavigation"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinInfotainment ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "All navigation actions"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Navigation"@en .
-
-vsso:OBDCatalyst a owl:Class ;
-    rdfs:label "OBDCatalyst"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:OBD ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Catalyst signals"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.OBD.Catalyst"@en .
-
-vsso:BodyWindshield a owl:Class ;
-    rdfs:label "BodyWindshield"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Body ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Windshield signals"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Body.Windshield"@en .
-
-vsso:CabinInfotainment a owl:Class ;
-    rdfs:label "CabinInfotainment"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Cabin ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Infotainment system"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment"@en .
-
-vsso:PowertrainFuelSystem a owl:Class ;
-    rdfs:label "PowertrainFuelSystem"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Powertrain ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Fuel system data."@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Powertrain.FuelSystem"@en .
-
-vsso:PowertrainTransmission a owl:Class ;
-    rdfs:label "PowertrainTransmission"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Powertrain ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Transmission-specific data, stopping at the drive shafts."@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Transmission"@en .
-
-vsso:VersionVSS a owl:Class ;
-    rdfs:label "VersionVSS"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Supported Version of VSS"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.VersionVSS"@en .
-
-vsso:Powertrain a owl:Class ;
-    rdfs:label "Powertrain"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Powertrain data for battery management, etc."@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Powertrain"@en .
-
-vsso:PowertrainElectricMotor a owl:Class ;
-    rdfs:label "PowertrainElectricMotor"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Powertrain ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Electric Motor specific data."@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Powertrain.ElectricMotor"@en .
-
-vsso:ADAS a owl:Class ;
-    rdfs:label "ADAS"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "All Advanced Driver Assist Systems data."@en ;
-    vsso-core:vssFacetedClassification "Vehicle.ADAS"@en .
-
-vsso:OBD a owl:Class ;
-    rdfs:label "OBD"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "OBD data."@en ;
-    vsso-core:vssFacetedClassification "Vehicle.OBD"@en .
-
-vsso:PowertrainBattery a owl:Class ;
-    rdfs:label "PowertrainBattery"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Powertrain ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Battery Management data."@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery"@en .
-
-vsso:SeatSwitch a owl:Class ;
-    rdfs:label "SeatSwitch"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:CabinSeat ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Seat switch signals"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch"@en .
-
-vsso:CabinSeat a owl:Class ;
-    rdfs:label "CabinSeat"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Cabin ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "All seats."@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat"@en .
-
-vsso:ChassisAxle a owl:Class ;
+vsso:ChassisAxle a vsso-core:VehicleComponent ;
     rdfs:label "ChassisAxle"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Chassis ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
     skos:definition "Axle signals"@en ;
+    vsso-core:partOf vsso:Chassis ;
     vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle"@en .
 
-vsso:Body a owl:Class ;
-    rdfs:label "Body"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "All body components."@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Body"@en .
+vsso:ChassisBrake a vsso-core:VehicleComponent ;
+    rdfs:label "ChassisBrake"@en ;
+    skos:definition "Brake system signals"@en ;
+    vsso-core:partOf vsso:Chassis ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.Brake"@en .
 
-vsso:Cabin a owl:Class ;
-    rdfs:label "Cabin"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "All in-cabin components, including doors."@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Cabin"@en .
+vsso:ChassisParkingBrake a vsso-core:VehicleComponent ;
+    rdfs:label "ChassisParkingBrake"@en ;
+    skos:definition "Parking brake signals"@en ;
+    vsso-core:partOf vsso:Chassis ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.ParkingBrake"@en .
 
-vsso:Chassis a owl:Class ;
-    rdfs:label "Chassis"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "All data concerning steering, suspension, wheels, and brakes."@en ;
-    vsso-core:vssFacetedClassification "Vehicle.Chassis"@en .
+vsso:ChassisTrailer a vsso-core:VehicleComponent ;
+    rdfs:label "ChassisTrailer"@en ;
+    skos:definition "Trailer signals"@en ;
+    vsso-core:partOf vsso:Chassis ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.Trailer"@en .
 
-vsso:PowertrainCombustionEngine a owl:Class ;
+vsso:MirrorsHeating a vsso-core:VehicleComponent ;
+    rdfs:label "MirrorsHeating"@en ;
+    skos:definition "Mirror heater signals"@en ;
+    vsso-core:partOf vsso:BodyMirrors ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Mirrors.Heating"@en .
+
+vsso:PowertrainElectricMotor a vsso-core:VehicleComponent ;
+    rdfs:label "PowertrainElectricMotor"@en ;
+    skos:definition "Electric Motor specific data."@en ;
+    vsso-core:partOf vsso:Powertrain ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.ElectricMotor"@en .
+
+vsso:SeatAirbag a vsso-core:VehicleComponent ;
+    rdfs:label "SeatAirbag"@en ;
+    skos:definition "Airbag signals"@en ;
+    vsso-core:partOf vsso:CabinSeat ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Airbag"@en .
+
+vsso:SeatHeadRestraint a vsso-core:VehicleComponent ;
+    rdfs:label "SeatHeadRestraint"@en ;
+    skos:definition "Head restraint settings"@en ;
+    vsso-core:partOf vsso:CabinSeat ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.HeadRestraint"@en .
+
+vsso:SeatOccupant a vsso-core:VehicleComponent ;
+    rdfs:label "SeatOccupant"@en ;
+    skos:definition "Occupant data."@en ;
+    vsso-core:partOf vsso:CabinSeat ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Occupant"@en .
+
+vsso:SeatSideBolster a vsso-core:VehicleComponent ;
+    rdfs:label "SeatSideBolster"@en ;
+    skos:definition "Side bolster settings"@en ;
+    vsso-core:partOf vsso:CabinSeat ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.SideBolster"@en .
+
+vsso:Trailer a vsso-core:VehicleComponent ;
+    rdfs:label "Trailer"@en ;
+    skos:definition "Trailer signals"@en ;
+    vsso-core:partOf vsso:Vehicle ;
+    vsso-core:vssFacetedClassification "Vehicle.Trailer"@en .
+
+vsso:WindshieldHeating a vsso-core:VehicleComponent ;
+    rdfs:label "WindshieldHeating"@en ;
+    skos:definition "Windshield heater signals"@en ;
+    vsso-core:partOf vsso:BodyWindshield ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Windshield.Heating"@en .
+
+vsso:WindshieldWiping a vsso-core:VehicleComponent ;
+    rdfs:label "WindshieldWiping"@en ;
+    skos:definition "Windshield wiper signals"@en ;
+    vsso-core:partOf vsso:BodyWindshield ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Windshield.Wiping"@en .
+
+vsso:ADASObstacleDetection a vsso-core:VehicleComponent ;
+    rdfs:label "ADASObstacleDetection"@en ;
+    skos:definition "Signals form Obstacle Sensor System"@en ;
+    vsso-core:partOf vsso:ADAS ;
+    vsso-core:vssFacetedClassification "Vehicle.ADAS.ObstacleDetection"@en .
+
+vsso:AxleWheel a vsso-core:VehicleComponent ;
+    rdfs:label "AxleWheel"@en ;
+    skos:definition "Wheel signals for axle"@en ;
+    vsso-core:partOf vsso:ChassisAxle ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle.Wheel"@en .
+
+vsso:BodyTrunk a vsso-core:VehicleComponent ;
+    rdfs:label "BodyTrunk"@en ;
+    skos:definition "Trunk status"@en ;
+    vsso-core:partOf vsso:Body ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Trunk"@en .
+
+vsso:CabinRearShade a vsso-core:VehicleComponent ;
+    rdfs:label "CabinRearShade"@en ;
+    skos:definition "Rear window shade."@en ;
+    vsso-core:partOf vsso:Cabin ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.RearShade"@en .
+
+vsso:CatalystBank1 a vsso-core:VehicleComponent ;
+    rdfs:label "CatalystBank1"@en ;
+    skos:definition "Catalyst bank 1 signals"@en ;
+    vsso-core:partOf vsso:OBDCatalyst ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.Catalyst.Bank1"@en .
+
+vsso:CatalystBank2 a vsso-core:VehicleComponent ;
+    rdfs:label "CatalystBank2"@en ;
+    skos:definition "Catalyst bank 2 signals"@en ;
+    vsso-core:partOf vsso:OBDCatalyst ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.Catalyst.Bank2"@en .
+
+vsso:ChargingTimer a vsso-core:VehicleComponent ;
+    rdfs:label "ChargingTimer"@en ;
+    skos:definition "Properties related to timing of battery charging sessions."@en ;
+    vsso-core:partOf vsso:BatteryCharging ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Charging.Timer"@en .
+
+vsso:DoorShade a vsso-core:VehicleComponent ;
+    rdfs:label "DoorShade"@en ;
+    skos:definition "Side window shade"@en ;
+    vsso-core:partOf vsso:CabinDoor ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Door.Shade"@en .
+
+vsso:DriverIdentifier a vsso-core:VehicleComponent ;
+    rdfs:label "DriverIdentifier"@en ;
+    skos:definition "Identifier attributes based on OAuth 2.0."@en ;
+    vsso-core:partOf vsso:Driver ;
+    vsso-core:vssFacetedClassification "Vehicle.Driver.Identifier"@en .
+
+vsso:InfotainmentNavigation a vsso-core:VehicleComponent ;
+    rdfs:label "InfotainmentNavigation"@en ;
+    skos:definition "All navigation actions"@en ;
+    vsso-core:partOf vsso:CabinInfotainment ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Navigation"@en .
+
+vsso:NavigationDestinationSet a vsso-core:VehicleComponent ;
+    rdfs:label "NavigationDestinationSet"@en ;
+    skos:definition "A navigation has been selected."@en ;
+    vsso-core:partOf vsso:InfotainmentNavigation ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Navigation.DestinationSet"@en .
+
+vsso:OBDCatalyst a vsso-core:VehicleComponent ;
+    rdfs:label "OBDCatalyst"@en ;
+    skos:definition "Catalyst signals"@en ;
+    vsso-core:partOf vsso:OBD ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.Catalyst"@en .
+
+vsso:OBDO2 a vsso-core:VehicleComponent ;
+    rdfs:label "OBDO2"@en ;
+    skos:definition "Oxygen sensors (PID 14 - PID 1B)"@en ;
+    vsso-core:partOf vsso:OBD ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.O2"@en .
+
+vsso:OccupantIdentifier a vsso-core:VehicleComponent ;
+    rdfs:label "OccupantIdentifier"@en ;
+    skos:definition "Identifier attributes based on OAuth 2.0."@en ;
+    vsso-core:partOf vsso:SeatOccupant ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Occupant.Identifier"@en .
+
+vsso:SeatCushion a vsso-core:VehicleComponent ;
+    rdfs:label "SeatCushion"@en ;
+    skos:definition "Cushion (leg support) signals."@en ;
+    vsso-core:partOf vsso:CabinSeat ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Cushion"@en .
+
+vsso:SeatLumbar a vsso-core:VehicleComponent ;
+    rdfs:label "SeatLumbar"@en ;
+    skos:definition "Lumbar signals"@en ;
+    vsso-core:partOf vsso:CabinSeat ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Lumbar"@en .
+
+vsso:SunroofShade a vsso-core:VehicleComponent ;
+    rdfs:label "SunroofShade"@en ;
+    skos:definition "Sun roof shade status"@en ;
+    vsso-core:partOf vsso:CabinSunroof ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Sunroof.Shade"@en .
+
+vsso:SwitchHeadRestraint a vsso-core:VehicleComponent ;
+    rdfs:label "SwitchHeadRestraint"@en ;
+    skos:definition "Switches for SingleSeat.HeadRestraint.Height"@en ;
+    vsso-core:partOf vsso:SeatSwitch ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.HeadRestraint"@en .
+
+vsso:SwitchMassage a vsso-core:VehicleComponent ;
+    rdfs:label "SwitchMassage"@en ;
+    skos:definition "Switches for SingleSeat.Massage"@en ;
+    vsso-core:partOf vsso:SeatSwitch ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Massage"@en .
+
+vsso:SwitchRecline a vsso-core:VehicleComponent ;
+    rdfs:label "SwitchRecline"@en ;
+    skos:definition "Switches for SingleSeat.Recline"@en ;
+    vsso-core:partOf vsso:SeatSwitch ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Recline"@en .
+
+vsso:SwitchSideBolster a vsso-core:VehicleComponent ;
+    rdfs:label "SwitchSideBolster"@en ;
+    skos:definition "Switches for SingleSeat.SideBolster"@en ;
+    vsso-core:partOf vsso:SeatSwitch ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.SideBolster"@en .
+
+vsso:WindshieldWasherFluid a vsso-core:VehicleComponent ;
+    rdfs:label "WindshieldWasherFluid"@en ;
+    skos:definition "Windshield washer fluid signals"@en ;
+    vsso-core:partOf vsso:BodyWindshield ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Windshield.WasherFluid"@en .
+
+vsso:ADASABS a vsso-core:VehicleComponent ;
+    rdfs:label "ADASABS"@en ;
+    skos:definition "Antilock Braking System signals"@en ;
+    vsso-core:partOf vsso:ADAS ;
+    vsso-core:vssFacetedClassification "Vehicle.ADAS.ABS"@en .
+
+vsso:ADASCruiseControl a vsso-core:VehicleComponent ;
+    rdfs:label "ADASCruiseControl"@en ;
+    skos:definition "Signals from Cruise Control system"@en ;
+    vsso-core:partOf vsso:ADAS ;
+    vsso-core:vssFacetedClassification "Vehicle.ADAS.CruiseControl"@en .
+
+vsso:ADASESC a vsso-core:VehicleComponent ;
+    rdfs:label "ADASESC"@en ;
+    skos:definition "Electronic Stability Control System signals"@en ;
+    vsso-core:partOf vsso:ADAS ;
+    vsso-core:vssFacetedClassification "Vehicle.ADAS.ESC"@en .
+
+vsso:ADASLaneDepartureDetection a vsso-core:VehicleComponent ;
+    rdfs:label "ADASLaneDepartureDetection"@en ;
+    skos:definition "Signals from Land Departure Detection System"@en ;
+    vsso-core:partOf vsso:ADAS ;
+    vsso-core:vssFacetedClassification "Vehicle.ADAS.LaneDepartureDetection"@en .
+
+vsso:ADASTCS a vsso-core:VehicleComponent ;
+    rdfs:label "ADASTCS"@en ;
+    skos:definition "Traction Control System signals"@en ;
+    vsso-core:partOf vsso:ADAS ;
+    vsso-core:vssFacetedClassification "Vehicle.ADAS.TCS"@en .
+
+vsso:Acceleration a vsso-core:VehicleComponent ;
+    rdfs:label "Acceleration"@en ;
+    skos:definition "Spatial acceleration"@en ;
+    vsso-core:partOf vsso:Vehicle ;
+    vsso-core:vssFacetedClassification "Vehicle.Acceleration"@en .
+
+vsso:AngularVelocity a vsso-core:VehicleComponent ;
+    rdfs:label "AngularVelocity"@en ;
+    skos:definition "Spatial rotation"@en ;
+    vsso-core:partOf vsso:Vehicle ;
+    vsso-core:vssFacetedClassification "Vehicle.AngularVelocity"@en .
+
+vsso:BatteryStateOfCharge a vsso-core:VehicleComponent ;
+    rdfs:label "BatteryStateOfCharge"@en ;
+    skos:definition "Information on the state of charge of the vehicle's high voltage battery."@en ;
+    vsso-core:partOf vsso:PowertrainBattery ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.StateOfCharge"@en .
+
+vsso:BodyMirrors a vsso-core:VehicleComponent ;
+    rdfs:label "BodyMirrors"@en ;
+    skos:definition "All mirrors"@en ;
+    vsso-core:partOf vsso:Body ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Mirrors"@en .
+
+vsso:BodyWindshield a vsso-core:VehicleComponent ;
+    rdfs:label "BodyWindshield"@en ;
+    skos:definition "Windshield signals"@en ;
+    vsso-core:partOf vsso:Body ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Windshield"@en .
+
+vsso:CabinInfotainment a vsso-core:VehicleComponent ;
+    rdfs:label "CabinInfotainment"@en ;
+    skos:definition "Infotainment system"@en ;
+    vsso-core:partOf vsso:Cabin ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment"@en .
+
+vsso:CabinSunroof a vsso-core:VehicleComponent ;
+    rdfs:label "CabinSunroof"@en ;
+    skos:definition "Sun roof status."@en ;
+    vsso-core:partOf vsso:Cabin ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Sunroof"@en .
+
+vsso:ChassisSteeringWheel a vsso-core:VehicleComponent ;
+    rdfs:label "ChassisSteeringWheel"@en ;
+    skos:definition "Steering wheel signals"@en ;
+    vsso-core:partOf vsso:Chassis ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.SteeringWheel"@en .
+
+vsso:CombustionEngineDieselParticulateFilter a vsso-core:VehicleComponent ;
+    rdfs:label "CombustionEngineDieselParticulateFilter"@en ;
+    skos:definition "Diesel Particulate Filter signals"@en ;
+    vsso-core:partOf vsso:PowertrainCombustionEngine ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.DieselParticulateFilter"@en .
+
+vsso:HVACStation a vsso-core:VehicleComponent ;
+    rdfs:label "HVACStation"@en ;
+    skos:definition "HVAC for single station in the vehicle"@en ;
+    vsso-core:partOf vsso:CabinHVAC ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.HVAC.Station"@en .
+
+vsso:LightsSpotlight a vsso-core:VehicleComponent ;
+    rdfs:label "LightsSpotlight"@en ;
+    skos:definition "Spotlight for a specific area in the vehicle."@en ;
+    vsso-core:partOf vsso:CabinLights ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Lights.Spotlight"@en .
+
+vsso:OBDDriveCycleStatus a vsso-core:VehicleComponent ;
+    rdfs:label "OBDDriveCycleStatus"@en ;
+    skos:definition "PID 41 - OBD status for the current drive cycle"@en ;
+    vsso-core:partOf vsso:OBD ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.DriveCycleStatus"@en .
+
+vsso:OBDO2WR a vsso-core:VehicleComponent ;
+    rdfs:label "OBDO2WR"@en ;
+    skos:definition "Wide range/band oxygen sensors (PID 24 - 2B and PID 34 - 3B)"@en ;
+    vsso-core:partOf vsso:OBD ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.O2WR"@en .
+
+vsso:OBDStatus a vsso-core:VehicleComponent ;
+    rdfs:label "OBDStatus"@en ;
+    skos:definition "PID 01 - OBD status"@en ;
+    vsso-core:partOf vsso:OBD ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD.Status"@en .
+
+vsso:PowertrainCombustionEngine a vsso-core:VehicleComponent ;
     rdfs:label "PowertrainCombustionEngine"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso:Powertrain ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
     skos:definition "Engine-specific data, stopping at the bell housing."@en ;
+    vsso-core:partOf vsso:Powertrain ;
     vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine"@en .
 
-vsso:VehicleIdentification a owl:Class ;
-    rdfs:label "VehicleIdentification"@en ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom vsso-core:Vehicle ;
-            owl:onProperty vsso-core:partOf ],
-        vsso-core:VehicleComponent ;
-    skos:definition "Attributes that identify a vehicle"@en ;
-    vsso-core:vssFacetedClassification "Vehicle.VehicleIdentification"@en .
+vsso:Service a vsso-core:VehicleComponent ;
+    rdfs:label "Service"@en ;
+    skos:definition "Service data."@en ;
+    vsso-core:partOf vsso:Vehicle ;
+    vsso-core:vssFacetedClassification "Vehicle.Service"@en .
+
+vsso:WheelTire a vsso-core:VehicleComponent ;
+    rdfs:label "WheelTire"@en ;
+    skos:definition "Tire signals for wheel"@en ;
+    vsso-core:partOf vsso:AxleWheel ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle.Wheel.Tire"@en .
+
+vsso:DoorWindow a vsso-core:VehicleComponent ;
+    rdfs:label "DoorWindow"@en ;
+    skos:definition "Door window status"@en ;
+    vsso-core:partOf vsso:CabinDoor ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Door.Window"@en .
+
+vsso:SwitchCushion a vsso-core:VehicleComponent ;
+    rdfs:label "SwitchCushion"@en ;
+    skos:definition "Switches for SingleSeat.Cushion"@en ;
+    vsso-core:partOf vsso:SeatSwitch ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Cushion"@en .
+
+vsso:SwitchLumbar a vsso-core:VehicleComponent ;
+    rdfs:label "SwitchLumbar"@en ;
+    skos:definition "Switches for SingleSeat.Lumbar"@en ;
+    vsso-core:partOf vsso:SeatSwitch ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch.Lumbar"@en .
+
+vsso:WheelBrake a vsso-core:VehicleComponent ;
+    rdfs:label "WheelBrake"@en ;
+    skos:definition "Brake signals for wheel"@en ;
+    vsso-core:partOf vsso:AxleWheel ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis.Axle.Wheel.Brake"@en .
+
+vsso:CabinDoor a vsso-core:VehicleComponent ;
+    rdfs:label "CabinDoor"@en ;
+    skos:definition "All doors, including windows and switches"@en ;
+    vsso-core:partOf vsso:Cabin ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Door"@en .
+
+vsso:CurrentLocation a vsso-core:VehicleComponent ;
+    rdfs:label "CurrentLocation"@en ;
+    skos:definition "The current latitude and longitude of the vehicle."@en ;
+    vsso-core:partOf vsso:Vehicle ;
+    vsso-core:vssFacetedClassification "Vehicle.CurrentLocation"@en .
+
+vsso:ElectricMotorMotor a vsso-core:VehicleComponent ;
+    rdfs:label "ElectricMotorMotor"@en ;
+    skos:definition "motor signals"@en ;
+    vsso-core:partOf vsso:PowertrainElectricMotor ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.ElectricMotor.Motor"@en .
+
+vsso:InfotainmentMedia a vsso-core:VehicleComponent ;
+    rdfs:label "InfotainmentMedia"@en ;
+    skos:definition "All Media actions"@en ;
+    vsso-core:partOf vsso:CabinInfotainment ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Media"@en .
+
+vsso:MediaPlayed a vsso-core:VehicleComponent ;
+    rdfs:label "MediaPlayed"@en ;
+    skos:definition "Collection of signals updated in concert when a new media is played"@en ;
+    vsso-core:partOf vsso:InfotainmentMedia ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Media.Played"@en .
+
+vsso:ADAS a vsso-core:VehicleComponent ;
+    rdfs:label "ADAS"@en ;
+    skos:definition "All Advanced Driver Assist Systems data."@en ;
+    vsso-core:partOf vsso:Vehicle ;
+    vsso-core:vssFacetedClassification "Vehicle.ADAS"@en .
+
+vsso:CabinHVAC a vsso-core:VehicleComponent ;
+    rdfs:label "CabinHVAC"@en ;
+    skos:definition "Climate control"@en ;
+    vsso-core:partOf vsso:Cabin ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.HVAC"@en .
+
+vsso:CabinLights a vsso-core:VehicleComponent ;
+    rdfs:label "CabinLights"@en ;
+    skos:definition "Interior lights signals and sensors"@en ;
+    vsso-core:partOf vsso:Cabin ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Lights"@en .
+
+vsso:Chassis a vsso-core:VehicleComponent ;
+    rdfs:label "Chassis"@en ;
+    skos:definition "All data concerning steering, suspension, wheels, and brakes."@en ;
+    vsso-core:partOf vsso:Vehicle ;
+    vsso-core:vssFacetedClassification "Vehicle.Chassis"@en .
+
+vsso:Driver a vsso-core:VehicleComponent ;
+    rdfs:label "Driver"@en ;
+    skos:definition "Driver data."@en ;
+    vsso-core:partOf vsso:Vehicle ;
+    vsso-core:vssFacetedClassification "Vehicle.Driver"@en .
+
+vsso:NavigationCurrentLocation a vsso-core:VehicleComponent ;
+    rdfs:label "NavigationCurrentLocation"@en ;
+    skos:definition "The current latitude and longitude of the vehicle."@en ;
+    vsso-core:partOf vsso:InfotainmentNavigation ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.Navigation.CurrentLocation"@en .
+
+vsso:Powertrain a vsso-core:VehicleComponent ;
+    rdfs:label "Powertrain"@en ;
+    skos:definition "Powertrain data for battery management, etc."@en ;
+    vsso-core:partOf vsso:Vehicle ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain"@en .
+
+vsso:Body a vsso-core:VehicleComponent ;
+    rdfs:label "Body"@en ;
+    skos:definition "All body components."@en ;
+    vsso-core:partOf vsso:Vehicle ;
+    vsso-core:vssFacetedClassification "Vehicle.Body"@en .
+
+vsso:InfotainmentHMI a vsso-core:VehicleComponent ;
+    rdfs:label "InfotainmentHMI"@en ;
+    skos:definition "HMI related signals"@en ;
+    vsso-core:partOf vsso:CabinInfotainment ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Infotainment.HMI"@en .
+
+vsso:PowertrainBattery a vsso-core:VehicleComponent ;
+    rdfs:label "PowertrainBattery"@en ;
+    skos:definition "Battery Management data."@en ;
+    vsso-core:partOf vsso:Powertrain ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery"@en .
+
+vsso:PowertrainFuelSystem a vsso-core:VehicleComponent ;
+    rdfs:label "PowertrainFuelSystem"@en ;
+    skos:definition "Fuel system data."@en ;
+    vsso-core:partOf vsso:Powertrain ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.FuelSystem"@en .
+
+vsso:Cabin a vsso-core:VehicleComponent ;
+    rdfs:label "Cabin"@en ;
+    skos:definition "All in-cabin components, including doors."@en ;
+    vsso-core:partOf vsso:Vehicle ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin"@en .
+
+vsso:CombustionEngineEngine a vsso-core:VehicleComponent ;
+    rdfs:label "CombustionEngineEngine"@en ;
+    skos:definition "Engine signals"@en ;
+    vsso-core:partOf vsso:PowertrainCombustionEngine ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.CombustionEngine.Engine"@en .
+
+vsso:PowertrainTransmission a vsso-core:VehicleComponent ;
+    rdfs:label "PowertrainTransmission"@en ;
+    skos:definition "Transmission-specific data, stopping at the drive shafts."@en ;
+    vsso-core:partOf vsso:Powertrain ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Transmission"@en .
+
+vsso:BodyLights a vsso-core:VehicleComponent ;
+    rdfs:label "BodyLights"@en ;
+    skos:definition "All lights"@en ;
+    vsso-core:partOf vsso:Body ;
+    vsso-core:vssFacetedClassification "Vehicle.Body.Lights"@en .
+
+vsso:BatteryCharging a vsso-core:VehicleComponent ;
+    rdfs:label "BatteryCharging"@en ;
+    skos:definition "Properties related to battery charging"@en ;
+    vsso-core:partOf vsso:PowertrainBattery ;
+    vsso-core:vssFacetedClassification "Vehicle.Powertrain.Battery.Charging"@en .
+
+vsso:SeatSwitch a vsso-core:VehicleComponent ;
+    rdfs:label "SeatSwitch"@en ;
+    skos:definition "Seat switch signals"@en ;
+    vsso-core:partOf vsso:CabinSeat ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat.Switch"@en .
+
+vsso:CabinSeat a vsso-core:VehicleComponent ;
+    rdfs:label "CabinSeat"@en ;
+    skos:definition "All seats."@en ;
+    vsso-core:partOf vsso:Cabin ;
+    vsso-core:vssFacetedClassification "Vehicle.Cabin.Seat"@en .
+
+vsso:Vehicle rdfs:label "Vehicle"@en ;
+    skos:definition "High-level vehicle data."@en ;
+    vsso-core:vssFacetedClassification "Vehicle"@en .
+
+vsso:OBD a vsso-core:VehicleComponent ;
+    rdfs:label "OBD"@en ;
+    skos:definition "OBD data."@en ;
+    vsso-core:partOf vsso:Vehicle ;
+    vsso-core:vssFacetedClassification "Vehicle.OBD"@en .
 
 


### PR DESCRIPTION
Output of new tooling in https://github.com/COVESA/vss-tools/pull/160

- DVP now instances
- use of `skos:definition` instead of `rdfs:comment`
- `rdfs:comment` where vss uses comments (new in 3.0)
- dot notated path in separate annotation property

Signed-off-by: Daniel Wilms <Daniel.DW.Wilms@bmw.de>